### PR TITLE
Target a specific TimescaleDB image version

### DIFF
--- a/compose/docker-compose-db.yml
+++ b/compose/docker-compose-db.yml
@@ -15,7 +15,7 @@ services:
       DATABASE_PORT: 5432
 
   ipld-eth-db:
-    image: timescale/timescaledb:latest-pg14
+    image: timescale/timescaledb:2.8.1-pg14
     restart: always
     environment:
       POSTGRES_USER: "vdbm"


### PR DESCRIPTION
Docker has evil behavior where the version of any image used can depend on when it was pulled from its registry. Therefore use of `latest` is discouraged because you can end up with a much older image than you expect, with no obvious way to tell.

