### PR TITLE
Upgrade watcher-ts version in the mobymask stack

### DIFF
--- a/compose/docker-compose-watcher-mobymask.yml
+++ b/compose/docker-compose-watcher-mobymask.yml
@@ -32,7 +32,7 @@ services:
     image: cerc/watcher-mobymask:local
     command: ["sh", "-c", "yarn server"]
     volumes:
-      - ../config/watcher-mobymask/mobymask-watcher.toml:/app/watcher-ts/packages/mobymask-watcher/environments/local.toml
+      - ../config/watcher-mobymask/mobymask-watcher.toml:/app/packages/mobymask-watcher/environments/local.toml
     ports:
       - "0.0.0.0:3001:3001"
       - "0.0.0.0:9001:9001"
@@ -55,13 +55,11 @@ services:
     image: cerc/watcher-mobymask:local
     command: ["sh", "-c", "yarn job-runner"]
     volumes:
-      - ../config/watcher-mobymask/mobymask-watcher.toml:/app/watcher-ts/packages/mobymask-watcher/environments/local.toml
+      - ../config/watcher-mobymask/mobymask-watcher.toml:/app/packages/mobymask-watcher/environments/local.toml
     ports:
       - "0.0.0.0:9000:9000"
     extra_hosts:
       - "ipld-eth-server:host-gateway"
 
 volumes:
-  indexer_db_data:
   watcher_db_data:
-  

--- a/compose/docker-compose-watcher-mobymask.yml
+++ b/compose/docker-compose-watcher-mobymask.yml
@@ -4,7 +4,7 @@ version: '3.2'
 
 services:
 
-  watcher-db:
+  mobymask-watcher-db:
     restart: unless-stopped
     image: postgres:14-alpine
     environment:
@@ -14,7 +14,7 @@ services:
       - POSTGRES_PASSWORD=password
     volumes:
       - ../config/postgresql/multiple-postgressql-databases.sh:/docker-entrypoint-initdb.d/multiple-postgressql-databases.sh
-      - watcher_db_data:/var/lib/postgresql/data
+      - mobymask_watcher_db_data:/var/lib/postgresql/data
     ports:
       - "0.0.0.0:15432:5432"
     healthcheck:
@@ -27,7 +27,7 @@ services:
   mobymask-watcher-server:
     restart: unless-stopped
     depends_on:
-      watcher-db:
+      mobymask-watcher-db:
         condition: service_healthy
     image: cerc/watcher-mobymask:local
     command: ["sh", "-c", "yarn server"]
@@ -50,7 +50,7 @@ services:
     depends_on:
       mobymask-watcher-server:
         condition: service_healthy
-      watcher-db:
+      mobymask-watcher-db:
         condition: service_healthy
     image: cerc/watcher-mobymask:local
     command: ["sh", "-c", "yarn job-runner"]
@@ -62,4 +62,4 @@ services:
       - "ipld-eth-server:host-gateway"
 
 volumes:
-  watcher_db_data:
+  mobymask_watcher_db_data:

--- a/config/watcher-mobymask/mobymask-watcher.toml
+++ b/config/watcher-mobymask/mobymask-watcher.toml
@@ -27,7 +27,7 @@
 
 [database]
   type = "postgres"
-  host = "watcher-db"
+  host = "mobymask-watcher-db"
   port = 5432
   database = "mobymask-watcher"
   username = "vdbm"
@@ -37,8 +37,8 @@
 
 [upstream]
   [upstream.ethServer]
-    gqlApiEndpoint = "http://ipld-eth-server:8082/graphql"
-    rpcProviderEndpoint = "http://ipld-eth-server:8081"
+    gqlApiEndpoint = "http://ipld-eth-server:8083/graphql"
+    rpcProviderEndpoint = "http://ipld-eth-server:8082"
     blockDelayInMilliSecs = 60000
 
   [upstream.cache]
@@ -47,7 +47,7 @@
     deleteOnStart = false
 
 [jobQueue]
-  dbConnectionString = "postgres://vdbm:password@watcher-db/mobymask-watcher-job-queue"
+  dbConnectionString = "postgres://vdbm:password@mobymask-watcher-db/mobymask-watcher-job-queue"
   maxCompletionLagInSecs = 300
   jobDelayInMilliSecs = 100
   eventsInBatch = 50

--- a/container-build/cerc-watcher-mobymask/Dockerfile
+++ b/container-build/cerc-watcher-mobymask/Dockerfile
@@ -5,23 +5,10 @@ RUN apk --update --no-cache add git python3 alpine-sdk
 
 WORKDIR /app
 
-COPY assemblyscript assemblyscript
-COPY watcher-ts watcher-ts
+COPY . .
 
-# TODO: needs branch ng-integrate-asyncify
-# We use a mixture of npm and yarn below because the upstream
-# project checked in an npm package-log.json file
-RUN echo "Building assemblyscript" && \
-    cd assemblyscript && \
-    npm install && npm run build && yarn link
+RUN echo "Building watcher-ts" && \
+    git checkout v0.2.19 && \
+    yarn && yarn build
 
-# TODO: needs branch v0.2.13
-# The shenanigans below is due to yarn and lerna being a dumpster-fire
-RUN echo "Linking watcher-ts to local assemblyscript" && \
-    cd watcher-ts/packages/graph-node && yarn remove @vulcanize/assemblyscript && \
-    yarn add https://github.com/vulcanize/assemblyscript.git#ng-integrate-asyncify
-
-RUN echo "Building watcher-tst" && \
-    cd watcher-ts && yarn && yarn link "@vulcanize/assemblyscript" && yarn build
-
-WORKDIR /app/watcher-ts/packages/mobymask-watcher
+WORKDIR /app/packages/mobymask-watcher

--- a/container-build/cerc-watcher-mobymask/build.sh
+++ b/container-build/cerc-watcher-mobymask/build.sh
@@ -4,5 +4,6 @@
 # See: https://stackoverflow.com/a/246128/1701505
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-# TODO: add a mechanism to pass two repos into a container rather than the parent directory as below
-docker build -t cerc/watcher-mobymask:local -f ${SCRIPT_DIR}/Dockerfile ${CERC_REPO_BASE_DIR}
+docker build -t cerc/watcher-mobymask:local -f ${SCRIPT_DIR}/Dockerfile ${CERC_REPO_BASE_DIR}/watcher-ts
+
+# TODO: add a mechanism to pass two repos into a container rather than the parent directory

--- a/stacks/mobymask/README.md
+++ b/stacks/mobymask/README.md
@@ -8,18 +8,11 @@ The instructions below show how to deploy a MobyMask watcher using laconic-stack
 This deployment expects that ipld-eth-server's endpoints are available on the local machine at http://ipld-eth-server.example.com:8083/graphql and http://ipld-eth-server.example.com:8082. More advanced configurations are supported by modifying the watcher's [config file](../../config/watcher-mobymask/mobymask-watcher.toml).
 ## Clone required repositories
 ```
-$ laconic-so setup-repositories --include vulcanize/assemblyscript,cerc-io/watcher-ts
-```
-Checkout required branches for the current release:
-```
-$ cd ~/cerc/assemblyscript
-$ git checkout ng-integrate-asyncify
-$ cd ~/cerc/watcher-ts
-$ git checkout v0.2.13
+$ laconic-so setup-repositories --include cerc-io/watcher-ts
 ```
 ## Build the watcher container
 ```
-$ laconic-sh build-containers --include cerc/watcher-mobymask
+$ laconic-so build-containers --include cerc/watcher-mobymask
 ```
 This should create a container with tag `cerc/watcher-mobymask` in the local image registry.
 ## Deploy the stack
@@ -33,6 +26,6 @@ $ docker exec -i <watcher-db-container> psql -U vdbm mobymask-watcher < config/w
 ```
 Finally start the remaining containers:
 ```
-$ laconic-so deploy-system --include watcher-mobymask
+$ laconic-so deploy-system --include watcher-mobymask up
 ```
 Correct operation should be verified by following the instructions [here](https://github.com/cerc-io/mobymask-watcher/tree/main/mainnet-watcher-only#run), checking GraphQL queries return valid results in the watcher's [playground](http://127.0.0.1:3001/graphql).

--- a/stacks/mobymask/README.md
+++ b/stacks/mobymask/README.md
@@ -16,13 +16,13 @@ $ laconic-so build-containers --include cerc/watcher-mobymask
 ```
 This should create a container with tag `cerc/watcher-mobymask` in the local image registry.
 ## Deploy the stack
-First the watcher database has to be initialized. Start only the watcher-db service:
+First the watcher database has to be initialized. Start only the mobymask-watcher-db service:
 ```
-$ laconic-so deploy-system --include watcher-mobymask up watcher-db
+$ laconic-so deploy-system --include watcher-mobymask up mobymask-watcher-db
 ```
 Next find the container's id using `docker ps` then run the following command to initialize the database:
 ```
-$ docker exec -i <watcher-db-container> psql -U vdbm mobymask-watcher < config/watcher-mobymask/mobymask-watcher-db.sql
+$ docker exec -i <mobymask-watcher-db-container> psql -U vdbm mobymask-watcher < config/watcher-mobymask/mobymask-watcher-db.sql
 ```
 Finally start the remaining containers:
 ```

--- a/stacks/mobymask/README.md
+++ b/stacks/mobymask/README.md
@@ -3,29 +3,51 @@
 The MobyMask watcher is a Laconic Network component that provides efficient access to MobyMask contract data from Ethereum, along with evidence allowing users to verify the correctness of that data. The watcher source code is available in [this repository](https://github.com/cerc-io/watcher-ts/tree/main/packages/mobymask-watcher) and a developer-oriented Docker Compose setup for the watcher can be found [here](https://github.com/cerc-io/mobymask-watcher). The watcher can be deployed automatically using the Laconic Stack Orchestrator tool as detailed below:
 
 ## Deploy the MobyMask Watcher
+
 The instructions below show how to deploy a MobyMask watcher using laconic-stack-orchestrator (the installation of which is covered [here](https://github.com/cerc-io/stack-orchestrator#user-mode)).
 
 This deployment expects that ipld-eth-server's endpoints are available on the local machine at http://ipld-eth-server.example.com:8083/graphql and http://ipld-eth-server.example.com:8082. More advanced configurations are supported by modifying the watcher's [config file](../../config/watcher-mobymask/mobymask-watcher.toml).
+
 ## Clone required repositories
+
 ```
 $ laconic-so setup-repositories --include cerc-io/watcher-ts
 ```
+
 ## Build the watcher container
+
 ```
 $ laconic-so build-containers --include cerc/watcher-mobymask
 ```
+
 This should create a container with tag `cerc/watcher-mobymask` in the local image registry.
+
 ## Deploy the stack
+
 First the watcher database has to be initialized. Start only the mobymask-watcher-db service:
+
 ```
 $ laconic-so deploy-system --include watcher-mobymask up mobymask-watcher-db
 ```
+
 Next find the container's id using `docker ps` then run the following command to initialize the database:
+
 ```
 $ docker exec -i <mobymask-watcher-db-container> psql -U vdbm mobymask-watcher < config/watcher-mobymask/mobymask-watcher-db.sql
 ```
+
 Finally start the remaining containers:
+
 ```
 $ laconic-so deploy-system --include watcher-mobymask up
 ```
+
 Correct operation should be verified by following the instructions [here](https://github.com/cerc-io/mobymask-watcher/tree/main/mainnet-watcher-only#run), checking GraphQL queries return valid results in the watcher's [playground](http://127.0.0.1:3001/graphql).
+
+## Clean up
+
+Stop all the services running in background:
+
+```bash
+$ laconic-so deploy-system --include watcher-mobymask down
+```

--- a/stacks/mobymask/stack.yml
+++ b/stacks/mobymask/stack.yml
@@ -1,8 +1,7 @@
 version: "1.0"
 name: mobymask-watcher
 repos:
-  - cerc-io/watcher-ts/v0.2.13
-  - vulcanize/assemblyscript/ng-integrate-asyncify
+  - cerc-io/watcher-ts/v0.2.19
 containers:
   - cerc/watcher-mobymask
 pods:


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/278

- Use pattern from other watcher stacks
- Upgrade `watcher-ts` to `v0.2.19`
- Update instructions