### PR TITLE
Improvements for building/deploying geth.

### DIFF
--- a/app/data/container-build/cerc-fixturenet-eth-geth/Dockerfile
+++ b/app/data/container-build/cerc-fixturenet-eth-geth/Dockerfile
@@ -4,12 +4,14 @@ FROM skylenet/ethereum-genesis-generator@sha256:210353ce7c898686bc5092f16c61220a
 FROM golang:1.18-alpine as delve
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
-FROM cerc/go-ethereum:local
+FROM cerc/go-ethereum:local as geth
+
+FROM alpine:latest
 RUN apk add --no-cache python3 python3-dev py3-pip curl wget jq build-base gettext libintl openssl bash bind-tools postgresql-client
 
-COPY --from=delve  /go/bin/dlv /
-COPY --from=ethgen /usr/local/bin/eth2-testnet-genesis /usr/local/bin/eth2-testnet-genesis
-COPY --from=ethgen /usr/local/bin/eth2-val-tools /usr/local/bin/eth2-val-tools
+COPY --from=delve  /go/bin/dlv /usr/local/bin/
+COPY --from=ethgen /usr/local/bin/eth2-testnet-genesis /usr/local/bin/
+COPY --from=ethgen /usr/local/bin/eth2-val-tools /usr/local/bin/
 COPY --from=ethgen /apps /apps
 
 RUN cd /apps/el-gen && pip3 install -r requirements.txt
@@ -19,6 +21,7 @@ COPY run-el.sh /opt/testnet/run.sh
 
 RUN cd /opt/testnet && make genesis-el
 
+COPY --from=geth  /usr/local/bin/geth /usr/local/bin/
 RUN geth init /opt/testnet/build/el/geth.json && rm -f ~/.ethereum/geth/nodekey
 
 ENTRYPOINT ["/opt/testnet/run.sh"]

--- a/app/data/container-build/cerc-fixturenet-eth-geth/run-el.sh
+++ b/app/data/container-build/cerc-fixturenet-eth-geth/run-el.sh
@@ -85,7 +85,7 @@ else
       --mine \
       --miner.threads=1 \
       --metrics \
-      --verbosity=${GETH_VERBOSITY:-3} \
-      --vmodule="${GETH_VMODULE:-statediff/*=6}" \
+      --verbosity=${CERC_GETH_VERBOSITY:-3} \
+      --vmodule="${CERC_GETH_VMODULE:-statediff/*=6}" \
       --miner.etherbase="${ETHERBASE}" ${STATEDIFF_OPTS}
 fi

--- a/app/data/container-build/cerc-fixturenet-eth-geth/run-el.sh
+++ b/app/data/container-build/cerc-fixturenet-eth-geth/run-el.sh
@@ -10,8 +10,8 @@ python3 -m http.server 9898 &
 cd $HOME_DIR
 
 START_CMD="geth"
-if [ "true" == "$CERC_REMOTE_DEBUG" ] && [ -x "/dlv" ]; then
-    START_CMD="/dlv --listen=:40000 --headless=true --api-version=2 --accept-multiclient exec /usr/local/bin/geth --continue --"
+if [ "true" == "$CERC_REMOTE_DEBUG" ] && [ -x "/usr/local/bin/dlv" ]; then
+    START_CMD="/usr/local/bin/dlv --listen=:40000 --headless=true --api-version=2 --accept-multiclient exec /usr/local/bin/geth --continue --"
 fi
 
 if [ "true" == "$RUN_BOOTNODE" ]; then
@@ -71,7 +71,7 @@ else
       --http \
       --http.addr="0.0.0.0" \
       --http.vhosts="*" \
-      --http.api="eth,web3,net,admin,personal" \
+      --http.api="eth,web3,net,admin,personal,debug,statediff" \
       --http.corsdomain="*" \
       --authrpc.addr="0.0.0.0" \
       --authrpc.vhosts="*" \
@@ -84,6 +84,8 @@ else
       --syncmode=full \
       --mine \
       --miner.threads=1 \
-      --verbosity=5 \
+      --metrics \
+      --verbosity=${GETH_VERBOSITY:-3} \
+      --vmodule="${GETH_VMODULE:-statediff/*=6}" \
       --miner.etherbase="${ETHERBASE}" ${STATEDIFF_OPTS}
 fi


### PR DESCRIPTION
1. Reorganize the Dockerfile for geth fixturenet so that rebuilding is much faster.
2. Tweak geth startup options to enable metrics, turn on the statediff API endpoint, and allow for ENV to control the log level (`$CERC_GETH_VERBOSITY`, `$CERC_GETH_VMODULE`)