### PR TITLE
Enable ETH_PROXY_ON_ERROR and debug logging for ipld-eth-server by default.

### DIFF
--- a/app/data/compose/docker-compose-ipld-eth-server.yml
+++ b/app/data/compose/docker-compose-ipld-eth-server.yml
@@ -20,9 +20,15 @@ services:
       DATABASE_USER: "vdbm"
       DATABASE_PASSWORD: "password"
       ETH_CHAIN_ID: 99
-      ETH_FORWARD_ETH_CALLS: $eth_forward_eth_calls
-      ETH_PROXY_ON_ERROR: $eth_proxy_on_error
-      ETH_HTTP_PATH: $eth_http_path
+      ETH_FORWARD_ETH_CALLS: "false"
+      ETH_FORWARD_GET_STORAGE_AT: "false"
+      ETH_PROXY_ON_ERROR: "true"
+      ETH_HTTP_PATH: "fixturenet-eth-geth-1:8545"
+      METRICS: "true"
+      PROM_HTTP: "true"
+      PROM_HTTP_ADDR: "0.0.0.0"
+      PROM_HTTP_PORT: "8090"
+      LOGRUS_LEVEL: "debug"
     volumes:
       - type: bind
         source: ../config/ipld-eth-server/chain.json


### PR DESCRIPTION
Update the default env for ipld-eth-server a bit to enable debug logging, metrics, and proxying on error.