### PR TITLE
Foundry debian-based container

### DIFF
--- a/app/data/container-build/cerc-foundry/build.sh
+++ b/app/data/container-build/cerc-foundry/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # Build a local version of the foundry-rs/foundry image
-docker build -t cerc/foundry:local -f ${CERC_REPO_BASE_DIR}/Dockerfile.debian ${CERC_REPO_BASE_DIR}/foundry
+docker build -t cerc/foundry:local -f ${CERC_REPO_BASE_DIR}/foundry/Dockerfile-debian ${CERC_REPO_BASE_DIR}/foundry

--- a/app/data/container-build/cerc-foundry/build.sh
+++ b/app/data/container-build/cerc-foundry/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # Build a local version of the foundry-rs/foundry image
-docker build -t cerc/foundry:local ${CERC_REPO_BASE_DIR}/foundry
+docker build -t cerc/foundry:local -f ${CERC_REPO_BASE_DIR}/Dockerfile.debian ${CERC_REPO_BASE_DIR}/foundry


### PR DESCRIPTION
Switches our foundry container build to the Debian dockerfile from dboreham/foundry.
This allows the foundry container to work on ARM systems.