### PR TITLE
Add Gitea action support via act_runner.

### DIFF
--- a/app/data/container-build/cerc-act_runner-task-executor/build.sh
+++ b/app/data/container-build/cerc-act_runner-task-executor/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Build a local version of the task executor for act_runner
+docker build -t cerc/act_runner-task-executor:local -f ${CERC_REPO_BASE_DIR}/act_runner/Dockerfile.task-executor ${CERC_REPO_BASE_DIR}/act_runner

--- a/app/data/container-build/cerc-act_runner/build.sh
+++ b/app/data/container-build/cerc-act_runner/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Build a local version of the act_runner image
+docker build -t cerc/act_runner:local -f ${CERC_REPO_BASE_DIR}/act_runner/Dockerfile ${CERC_REPO_BASE_DIR}/act_runner

--- a/app/data/container-image-list.txt
+++ b/app/data/container-image-list.txt
@@ -28,3 +28,5 @@ cerc/builder-js
 cerc/keycloak
 cerc/tx-spammer
 cerc/builder-gerbil
+cerc/act_runner
+cerc/act_runner-task-executor

--- a/app/data/repository-list.txt
+++ b/app/data/repository-list.txt
@@ -23,3 +23,4 @@ dboreham/foundry
 lirewine/gem
 lirewine/debug
 lirewine/crypto
+telackey/act_runner

--- a/app/data/stacks/package-registry/stack.yml
+++ b/app/data/stacks/package-registry/stack.yml
@@ -3,6 +3,10 @@ name: package-registry
 decription: "Local Package Registry"
 repos:
   - cerc-io/hosting
+  - telackey/act_runner
+containers:
+  - cerc/act_runner
+  - cerc/act_runner-task-executor
 pods:
   - name: gitea
     repository: cerc-io/hosting


### PR DESCRIPTION
```
❯ ./laconic-so --stack package-registry build-containers
...
❯ ./laconic-so --stack package-registry deploy up
[+] Running 4/4
 ⠿ Network laconic-b4589bc1ac500c2744804ffa96163e92_gitea       Created                                                                                                                        0.0s
 ⠿ Container laconic-b4589bc1ac500c2744804ffa96163e92-db-1      Started                                                                                                                        1.0s
 ⠿ Container laconic-b4589bc1ac500c2744804ffa96163e92-runner-1  Started                                                                                                                        1.0s
 ⠿ Container laconic-b4589bc1ac500c2744804ffa96163e92-server-1  Started                                                                                                                        1.6s
New user 'gitea_admin' has been successfully created!
This is your gitea access token: 2b5e389922afd7005a717ed459cc3eae3ac30ec1. Keep it safe and secure, it can not be fetched again from gitea.
To use with laconic-so set this environment variable: export CERC_NPM_AUTH_TOKEN=2b5e389922afd7005a717ed459cc3eae3ac30ec1
Created the organization cerc-io
Gitea was configured to use host name: gitea.local, ensure that this resolves to localhost, e.g. with sudo vi /etc/hosts
Success, gitea is properly initialized
```

<img width="1559" alt="Screenshot 2023-03-24 at 10 31 26 PM" src="https://user-images.githubusercontent.com/1649771/227689806-a19af3e7-c000-4c38-80fd-a213e0ebb20b.png">