### PR TITLE
Use dashes not underscore to match docker-compose file

### DIFF
--- a/app/data/container-build/cerc-act-runner-task-executor/build.sh
+++ b/app/data/container-build/cerc-act-runner-task-executor/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Build a local version of the task executor for act-runner
+docker build -t cerc/act-runner-task-executor:local -f ${CERC_REPO_BASE_DIR}/act_runner/Dockerfile.task-executor ${CERC_REPO_BASE_DIR}/act_runner

--- a/app/data/container-build/cerc-act-runner/build.sh
+++ b/app/data/container-build/cerc-act-runner/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Build a local version of the act-runner image
+docker build -t cerc/act-runner:local -f ${CERC_REPO_BASE_DIR}/act_runner/Dockerfile ${CERC_REPO_BASE_DIR}/act_runner

--- a/app/data/container-build/cerc-act_runner-task-executor/build.sh
+++ b/app/data/container-build/cerc-act_runner-task-executor/build.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-# Build a local version of the task executor for act_runner
-docker build -t cerc/act_runner-task-executor:local -f ${CERC_REPO_BASE_DIR}/act_runner/Dockerfile.task-executor ${CERC_REPO_BASE_DIR}/act_runner

--- a/app/data/container-build/cerc-act_runner/build.sh
+++ b/app/data/container-build/cerc-act_runner/build.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-# Build a local version of the act_runner image
-docker build -t cerc/act_runner:local -f ${CERC_REPO_BASE_DIR}/act_runner/Dockerfile ${CERC_REPO_BASE_DIR}/act_runner

--- a/app/data/stacks/package-registry/stack.yml
+++ b/app/data/stacks/package-registry/stack.yml
@@ -5,8 +5,8 @@ repos:
   - cerc-io/hosting
   - telackey/act_runner
 containers:
-  - cerc/act_runner
-  - cerc/act_runner-task-executor
+  - cerc/act-runner
+  - cerc/act-runner-task-executor
 pods:
   - name: gitea
     repository: cerc-io/hosting


### PR DESCRIPTION
Hosting repo used `act-runner` while we build `act_runner` here. Although the git repo is called `act_runner`, every other container we build uses dashes to let's be consistent.