### PR TITLE
[WIP] Replace laconicd with optimism in mobymask-v2 stack

### DIFF
--- a/app/data/compose/docker-compose-watcher-mobymask-v2.yml
+++ b/app/data/compose/docker-compose-watcher-mobymask-v2.yml
@@ -25,6 +25,7 @@ services:
     restart: unless-stopped
     image: cerc/mobymask:local
     working_dir: /app/packages/server
+    # TODO: Configure env file for ETH RPC URL & private key
     environment:
       - ENV=PROD
     command: ["sh", "-c", "npm start"]
@@ -109,11 +110,3 @@ services:
 volumes:
   mobymask_watcher_db_data:
   moby_data_server:
-
-networks:
-  # https://docs.docker.com/compose/networking/#configure-the-default-network
-  default:
-    # https://docs.docker.com/compose/networking/#use-a-pre-existing-network
-    name: mobymask-v2-network
-    external: true
-

--- a/app/data/config/fixturenet-optimism/optimism-contracts/run.sh
+++ b/app/data/config/fixturenet-optimism/optimism-contracts/run.sh
@@ -74,6 +74,7 @@ PROXY_JSON=$(cat deployments/getting-started/Proxy__OVM_L1StandardBridge.json)
 PROXY_ADDRESS=$(echo "$PROXY_JSON" | jq -r '.address')
 
 # Send balance to the above L2 address
+# TODO: Send balance using second account to reflect in L2
 yarn hardhat send-balance --to "${PROXY_ADDRESS}" --amount 1 --private-key "${L1_PRIV_KEY}" --network getting-started
 
 echo "Balance sent to Proxy L2 contract"

--- a/app/data/config/watcher-mobymask-v2/secrets.json
+++ b/app/data/config/watcher-mobymask-v2/secrets.json
@@ -1,5 +1,5 @@
 {
-    "rpcUrl": "http://laconicd:8545",
-    "privateKey": "GENESIS_ACCOUNT_PRIVATE_KEY",
+    "rpcUrl": "http://op-geth:8545",
+    "privateKey": "ROLLUP_ACCOUNT_PRIVATE_KEY",
     "baseURI": "http://127.0.0.1:3002/#"
 }

--- a/app/data/stacks/mobymask-v2/README.md
+++ b/app/data/stacks/mobymask-v2/README.md
@@ -28,10 +28,6 @@ git checkout v0.2.31
 cd ~/cerc/mobymask-ui
 git checkout laconic
 
-# laconicd
-cd ~/cerc/laconicd
-git checkout v0.8.0
-
 # MobyMask
 cd ~/cerc/MobyMask
 git checkout v0.1.1
@@ -47,55 +43,19 @@ This should create the required docker images in the local image registry.
 
 Deploy the stack:
 
-* Deploy the laconic chain
-
-  ```bash
-  laconic-so --stack mobymask-v2 deploy-system --include mobymask-laconicd up
-  ```
-
-* Check that laconic chain status is healthy
-
-  ```bash
-  docker ps
-  ```
-
-* Export the private key from laconicd
-
-  ```bash
-  laconic-so --stack mobymask-v2 deploy-system --include mobymask-laconicd exec laconicd "echo y | laconicd keys export mykey --unarmored-hex --unsafe"
-  ```
-
 * Set the private key in [secrets.json](../../config/watcher-mobymask-v2/secrets.json) file that will be used by mobymask container to deploy contract
 
-* Create a new account named `alice`
-
-  ```bash
-  laconic-so --stack mobymask-v2 deploy-system --include mobymask-laconicd exec laconicd "laconicd keys add alice"
-  ```
-
-* Transfer balance to new account
-
-  ```bash
-  laconic-so --stack mobymask-v2 deploy-system --include mobymask-laconicd exec laconicd 'laconicd tx bank send $(laconicd keys show mykey -a) $(laconicd keys show alice -a) 1000000000000000000000000aphoton --fees 2000aphoton'
-  ```
-
-* Export the private key of new account from laconicd
-
-  ```bash
-  laconic-so --stack mobymask-v2 deploy-system --include mobymask-laconicd exec laconicd "echo y | laconicd keys export alice --unarmored-hex --unsafe"
-  ```
-
-* Set the private key (`server.p2p.peer.l2TxConfig.privateKey`) in [watcher.toml](../../config/watcher-mobymask-v2/watcher.toml) file that will be used to start the peer that sends txs to L2 chain
+* Set the private key (`server.p2p.peer.l2TxConfig.privateKey`) in [watcher.toml](../../config/watcher-mobymask-v2/watcher-config-template.toml) file that will be used to start the peer that sends txs to L2 chain
 
   ```toml
   [server.p2p.peer.l2TxConfig]
-    privateKey = 'ALICE_PRIVATE_KEY'
+    privateKey = 'SECOND_ACCOUNT_PRIVATE_KEY'
   ```
 
-* Deploy the other containers
+* Deploy the containers
 
   ```bash
-  laconic-so --stack mobymask-v2 deploy-system --include watcher-mobymask-v2 up
+  laconic-so --stack mobymask-v2 deploy-system up
   ```
 
 * Check that all containers are healthy using `docker ps`
@@ -103,7 +63,7 @@ Deploy the stack:
   NOTE: The `mobymask-ui` container might not start. If mobymask-app is not running at http://localhost:3002, run command again to start the container
 
   ```bash
-  laconic-so --stack mobymask-v2 deploy-system --include watcher-mobymask-v2 up
+  laconic-so --stack mobymask-v2 deploy-system up
   ```
 
 ## Tests
@@ -111,7 +71,7 @@ Deploy the stack:
 Find the watcher container's id:
 
 ```bash
-laconic-so --stack mobymask-v2 deploy-system --include watcher-mobymask-v2 ps | grep "mobymask-watcher-server"
+laconic-so --stack mobymask-v2 deploy-system ps | grep "mobymask-watcher-server"
 ```
 
 Example output

--- a/app/data/stacks/mobymask-v2/demo.md
+++ b/app/data/stacks/mobymask-v2/demo.md
@@ -3,7 +3,7 @@
 * Get the root invite link URL for mobymask-app
 
   ```
-  laconic-so --stack mobymask-v2 deploy-system --include watcher-mobymask-v2 logs mobymask
+  laconic-so --stack mobymask-v2 deploy-system logs mobymask
   ```
 
   The invite link is seen at the end of the logs
@@ -34,7 +34,7 @@
   * Get the container id
 
     ```bash
-    laconic-so --stack mobymask-v2 deploy-system --include watcher-mobymask-v2 ps | grep mobymask-watcher-server
+    laconic-so --stack mobymask-v2 deploy-system ps | grep mobymask-watcher-server
     ```
 
   * Check logs
@@ -74,7 +74,7 @@
   * Get the deployed contract address
 
     ```bash
-    laconic-so --stack mobymask-v2 deploy-system --include watcher-mobymask-v2 exec mobymask-app "cat src/config.json"
+    laconic-so --stack mobymask-v2 deploy-system exec mobymask-app "cat src/config.json"
     ```
 
     The value of `address` field is the deployed contract address

--- a/app/data/stacks/mobymask-v2/stack.yml
+++ b/app/data/stacks/mobymask-v2/stack.yml
@@ -4,14 +4,11 @@ repos:
   - cerc-io/watcher-ts
   - cerc-io/react-peer
   - cerc-io/mobymask-ui
-  - cerc-io/laconicd
   - cerc-io/MobyMask
 containers:
   - cerc/watcher-mobymask-v2
   - cerc/react-peer
   - cerc/mobymask-ui
-  - cerc/laconicd
   - cerc/mobymask
 pods:
-  - mobymask-laconicd
   - watcher-mobymask-v2


### PR DESCRIPTION
Part of https://github.com/cerc-io/stack-orchestrator/issues/264

- Removed laconicd from mobymask-v2 stack