### PR TITLE
Separate out watcher and web-apps in mobymask-v2 stack

### DIFF
--- a/app/data/compose/docker-compose-mobymask-app.yml
+++ b/app/data/compose/docker-compose-mobymask-app.yml
@@ -1,7 +1,7 @@
 version: '3.2'
 
 services:
-  # Builds and serves the mobymask react-app
+  # Builds and serves the MobyMask react-app
   mobymask-app:
     image: cerc/mobymask-ui:local
     env_file:

--- a/app/data/compose/docker-compose-mobymask-app.yml
+++ b/app/data/compose/docker-compose-mobymask-app.yml
@@ -1,10 +1,13 @@
 version: '3.2'
 
 services:
+  # Builds and serves the mobymask react-app
   mobymask-app:
     image: cerc/mobymask-ui:local
     env_file:
       - ../config/watcher-mobymask-v2/mobymask-params.env
+    # Waits for watcher server to be up before app build
+    # Required when running with watcher stack to get deployed contract address
     command:
       - sh
       - -c

--- a/app/data/compose/docker-compose-mobymask-app.yml
+++ b/app/data/compose/docker-compose-mobymask-app.yml
@@ -2,20 +2,18 @@ version: '3.2'
 
 services:
   mobymask-app:
-    depends_on:
-      mobymask-watcher-server:
-        condition: service_healthy
-      mobymask:
-        condition: service_completed_successfully
     image: cerc/mobymask-ui:local
-    command: |
-      "./wait-for-it.sh -h $${WATCHER_HOST} -p $${WATCHER_PORT} -s -t 60 -- ./mobymask-app-start.sh"
+    env_file:
+      - ../config/watcher-mobymask-v2/mobymask-params.env
+    command:
+      - sh
+      - -c
+      - ./wait-for-it.sh -h $${WATCHER_HOST} -p $${WATCHER_PORT} -s -t 60 -- ./mobymask-app-start.sh
     volumes:
       - ../config/wait-for-it.sh:/app/wait-for-it.sh
-      - ../config/watcher-mobymask-v2/mobymask-app.env:/app/.env
       - ../config/watcher-mobymask-v2/mobymask-app-config.json:/app/src/mobymask-app-config.json
       - ../config/watcher-mobymask-v2/mobymask-app-start.sh:/app/mobymask-app-start.sh
-      - moby_data_server:/server
+      - mobymask_deployment:/server
     ports:
       - "0.0.0.0:3002:3000"
     healthcheck:
@@ -26,23 +24,5 @@ services:
       start_period: 10s
     shm_size: '1GB'
 
-  peer-test-app:
-    depends_on:
-      mobymask-watcher-server:
-        condition: service_healthy
-    image: cerc/react-peer:local
-    working_dir: /app/packages/test-app
-    command: ["sh", "-c", "yarn build && serve -s build"]
-    volumes:
-      - ../config/watcher-mobymask-v2/test-app-config.json:/app/packages/test-app/src/config.json
-    ports:
-      - "0.0.0.0:3003:3000"
-    healthcheck:
-      test: ["CMD", "nc", "-v", "localhost", "3000"]
-      interval: 20s
-      timeout: 5s
-      retries: 15
-      start_period: 10s
-
 volumes:
-  moby_data_server:
+  mobymask_deployment:

--- a/app/data/compose/docker-compose-mobymask-app.yml
+++ b/app/data/compose/docker-compose-mobymask-app.yml
@@ -11,7 +11,7 @@ services:
     command:
       - sh
       - -c
-      - ./wait-for-it.sh -h $${WATCHER_HOST} -p $${WATCHER_PORT} -s -t 60 -- ./mobymask-app-start.sh
+      - ./wait-for-it.sh -h $${WATCHER_HOST} -p $${WATCHER_PORT} -s -t 0 -- ./mobymask-app-start.sh
     volumes:
       - ../config/wait-for-it.sh:/app/wait-for-it.sh
       - ../config/watcher-mobymask-v2/mobymask-app-config.json:/app/src/mobymask-app-config.json

--- a/app/data/compose/docker-compose-mobymask-app.yml
+++ b/app/data/compose/docker-compose-mobymask-app.yml
@@ -1,0 +1,48 @@
+version: '3.2'
+
+services:
+  mobymask-app:
+    depends_on:
+      mobymask-watcher-server:
+        condition: service_healthy
+      mobymask:
+        condition: service_completed_successfully
+    image: cerc/mobymask-ui:local
+    command: |
+      "./wait-for-it.sh -h $${WATCHER_HOST} -p $${WATCHER_PORT} -s -t 60 -- ./mobymask-app-start.sh"
+    volumes:
+      - ../config/wait-for-it.sh:/app/wait-for-it.sh
+      - ../config/watcher-mobymask-v2/mobymask-app.env:/app/.env
+      - ../config/watcher-mobymask-v2/mobymask-app-config.json:/app/src/mobymask-app-config.json
+      - ../config/watcher-mobymask-v2/mobymask-app-start.sh:/app/mobymask-app-start.sh
+      - moby_data_server:/server
+    ports:
+      - "0.0.0.0:3002:3000"
+    healthcheck:
+      test: ["CMD", "nc", "-v", "localhost", "3000"]
+      interval: 20s
+      timeout: 5s
+      retries: 15
+      start_period: 10s
+    shm_size: '1GB'
+
+  peer-test-app:
+    depends_on:
+      mobymask-watcher-server:
+        condition: service_healthy
+    image: cerc/react-peer:local
+    working_dir: /app/packages/test-app
+    command: ["sh", "-c", "yarn build && serve -s build"]
+    volumes:
+      - ../config/watcher-mobymask-v2/test-app-config.json:/app/packages/test-app/src/config.json
+    ports:
+      - "0.0.0.0:3003:3000"
+    healthcheck:
+      test: ["CMD", "nc", "-v", "localhost", "3000"]
+      interval: 20s
+      timeout: 5s
+      retries: 15
+      start_period: 10s
+
+volumes:
+  moby_data_server:

--- a/app/data/compose/docker-compose-peer-test-app.yml
+++ b/app/data/compose/docker-compose-peer-test-app.yml
@@ -2,15 +2,14 @@ version: '3.2'
 
 services:
   peer-test-app:
-    depends_on:
-      mobymask-watcher-server:
-        condition: service_healthy
     image: cerc/react-peer:local
     working_dir: /app/packages/test-app
-    command: |
-      "./wait-for-it.sh -h $${WATCHER_HOST} -p $${WATCHER_PORT} -s -t 60 -- ./test-app-start.sh"
+    env_file:
+      - ../config/watcher-mobymask-v2/mobymask-params.env
+    command: ["sh", "./test-app-start.sh"]
     volumes:
-      - ../config/watcher-mobymask-v2/test-app-config.json:/app/packages/test-app/src/config.json
+      - ../config/watcher-mobymask-v2/test-app-config.json:/app/packages/test-app/src/test-app-config.json
+      - ../config/watcher-mobymask-v2/test-app-start.sh:/app/packages/test-app/test-app-start.sh
     ports:
       - "0.0.0.0:3003:3000"
     healthcheck:

--- a/app/data/compose/docker-compose-peer-test-app.yml
+++ b/app/data/compose/docker-compose-peer-test-app.yml
@@ -2,6 +2,7 @@ version: '3.2'
 
 services:
   peer-test-app:
+    # Builds and serves the peer-test react-app
     image: cerc/react-peer:local
     working_dir: /app/packages/test-app
     env_file:

--- a/app/data/compose/docker-compose-peer-test-app.yml
+++ b/app/data/compose/docker-compose-peer-test-app.yml
@@ -1,0 +1,21 @@
+version: '3.2'
+
+services:
+  peer-test-app:
+    depends_on:
+      mobymask-watcher-server:
+        condition: service_healthy
+    image: cerc/react-peer:local
+    working_dir: /app/packages/test-app
+    command: |
+      "./wait-for-it.sh -h $${WATCHER_HOST} -p $${WATCHER_PORT} -s -t 60 -- ./test-app-start.sh"
+    volumes:
+      - ../config/watcher-mobymask-v2/test-app-config.json:/app/packages/test-app/src/config.json
+    ports:
+      - "0.0.0.0:3003:3000"
+    healthcheck:
+      test: ["CMD", "nc", "-v", "localhost", "3000"]
+      interval: 20s
+      timeout: 5s
+      retries: 15
+      start_period: 10s

--- a/app/data/compose/docker-compose-watcher-mobymask-v2.yml
+++ b/app/data/compose/docker-compose-watcher-mobymask-v2.yml
@@ -76,48 +76,6 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
-  # TODO: Move to a separate pod
-  mobymask-app:
-    depends_on:
-      mobymask-watcher-server:
-        condition: service_healthy
-      mobymask:
-        condition: service_completed_successfully
-    image: cerc/mobymask-ui:local
-    command: ["sh", "mobymask-app-start.sh"]
-    volumes:
-      - ../config/watcher-mobymask-v2/mobymask-app.env:/app/.env
-      - ../config/watcher-mobymask-v2/mobymask-app-config.json:/app/src/mobymask-app-config.json
-      - ../config/watcher-mobymask-v2/mobymask-app-start.sh:/app/mobymask-app-start.sh
-      - mobymask_deployment:/server
-    ports:
-      - "0.0.0.0:3002:3000"
-    healthcheck:
-      test: ["CMD", "nc", "-v", "localhost", "3000"]
-      interval: 20s
-      timeout: 5s
-      retries: 15
-      start_period: 10s
-    shm_size: '1GB'
-
-  peer-test-app:
-    depends_on:
-      mobymask-watcher-server:
-        condition: service_healthy
-    image: cerc/react-peer:local
-    working_dir: /app/packages/test-app
-    command: ["sh", "-c", "yarn build && serve -s build"]
-    volumes:
-      - ../config/watcher-mobymask-v2/test-app-config.json:/app/packages/test-app/src/config.json
-    ports:
-      - "0.0.0.0:3003:3000"
-    healthcheck:
-      test: ["CMD", "nc", "-v", "localhost", "3000"]
-      interval: 20s
-      timeout: 5s
-      retries: 15
-      start_period: 10s
-
 volumes:
   mobymask_watcher_db_data:
   mobymask_deployment:

--- a/app/data/compose/docker-compose-watcher-mobymask-v2.yml
+++ b/app/data/compose/docker-compose-watcher-mobymask-v2.yml
@@ -26,6 +26,7 @@ services:
     working_dir: /app/packages/server
     env_file:
       - ../config/watcher-mobymask-v2/optimism-params.env
+      - ../config/watcher-mobymask-v2/mobymask-params.env
     environment:
       - ENV=PROD
     command:
@@ -54,6 +55,7 @@ services:
     image: cerc/watcher-mobymask-v2:local
     env_file:
       - ../config/watcher-mobymask-v2/optimism-params.env
+      - ../config/watcher-mobymask-v2/mobymask-params.env
     command: ["sh", "start-server.sh"]
     volumes:
       - ../config/watcher-mobymask-v2/watcher-config-template.toml:/app/packages/mobymask-v2-watcher/environments/watcher-config-template.toml

--- a/app/data/compose/docker-compose-watcher-mobymask-v2.yml
+++ b/app/data/compose/docker-compose-watcher-mobymask-v2.yml
@@ -1,6 +1,7 @@
 version: '3.2'
 
 services:
+  # Starts the postgres database for watcher
   mobymask-watcher-db:
     restart: unless-stopped
     image: postgres:14-alpine
@@ -21,6 +22,8 @@ services:
       retries: 15
       start_period: 10s
 
+  # Deploys mobymask contract and generates an invite link
+  # Deployment is skipped if DEPLOYED_CONTRACT env is already set
   mobymask:
     image: cerc/mobymask:local
     working_dir: /app/packages/server
@@ -29,6 +32,7 @@ services:
       - ../config/watcher-mobymask-v2/mobymask-params.env
     environment:
       - ENV=PROD
+    # Waits for L2 Optimism Geth and Node servers to be up before deploying contract
     command:
       - sh
       - -c
@@ -45,6 +49,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
+  # Starts the mobymask-v2-watcher server
   mobymask-watcher-server:
     restart: unless-stopped
     depends_on:
@@ -65,6 +70,7 @@ services:
       - ../config/watcher-mobymask-v2/start-server.sh:/app/packages/mobymask-v2-watcher/start-server.sh
       - mobymask_deployment:/server
       - fixturenet_geth_accounts:/geth-accounts:ro
+    # Expose GQL, metrics and relay node ports
     ports:
       - "0.0.0.0:3001:3001"
       - "0.0.0.0:9001:9001"

--- a/app/data/compose/docker-compose-watcher-mobymask-v2.yml
+++ b/app/data/compose/docker-compose-watcher-mobymask-v2.yml
@@ -1,7 +1,7 @@
 version: '3.2'
 
 services:
-  # Starts the postgres database for watcher
+  # Starts the PostgreSQL database for watcher
   mobymask-watcher-db:
     restart: unless-stopped
     image: postgres:14-alpine
@@ -22,7 +22,7 @@ services:
       retries: 15
       start_period: 10s
 
-  # Deploys mobymask contract and generates an invite link
+  # Deploys MobyMask contract and generates an invite link
   # Deployment is skipped if DEPLOYED_CONTRACT env is already set
   mobymask:
     image: cerc/mobymask:local

--- a/app/data/config/watcher-mobymask-v2/deploy-and-generate-invite.sh
+++ b/app/data/config/watcher-mobymask-v2/deploy-and-generate-invite.sh
@@ -4,6 +4,8 @@ if [ -n "$CERC_SCRIPT_DEBUG" ]; then
   set -x
 fi
 
+echo "Using L2 RPC endpoint ${L2_GETH_RPC}"
+
 if [ -f /geth-accounts/accounts.csv ]; then
   echo "Using L1 private key from the mounted volume"
   # Read the private key of L1 account to deploy contract
@@ -16,10 +18,9 @@ fi
 jq --arg privateKey "$PRIVATE_KEY_DEPLOYER" '.privateKey = $privateKey' secrets-template.json > secrets.json
 
 # Set the RPC URL
-export L2_GETH_URL="http://${L2_GETH_HOST}:${L2_GETH_PORT}"
-jq --arg rpcUrl "$L2_GETH_URL" '.rpcUrl = $rpcUrl' secrets.json > secrets_updated.json && mv secrets_updated.json secrets.json
+jq --arg rpcUrl "$L2_GETH_RPC" '.rpcUrl = $rpcUrl' secrets.json > secrets_updated.json && mv secrets_updated.json secrets.json
 
-export RPC_URL="${L2_GETH_URL}"
+export RPC_URL="${L2_GETH_RPC}"
 
 if [[ -n "$DEPLOYED_CONTRACT" ]]; then
   echo "DEPLOYED_CONTRACT is set to '$DEPLOYED_CONTRACT'"
@@ -48,7 +49,7 @@ fi
 # Wait until balance for deployer account is reflected
 cd ../hardhat
 while true; do
-  ACCOUNT_BALANCE=$(yarn balance --network optimism $PRIVATE_KEY_DEPLOYER | grep ETH)
+  ACCOUNT_BALANCE=$(yarn balance --network optimism "$PRIVATE_KEY_DEPLOYER" | grep ETH)
 
   if [ "$ACCOUNT_BALANCE" != "0.0 ETH" ]; then
     echo "Account balance updated: $ACCOUNT_BALANCE"

--- a/app/data/config/watcher-mobymask-v2/deploy-and-generate-invite.sh
+++ b/app/data/config/watcher-mobymask-v2/deploy-and-generate-invite.sh
@@ -21,6 +21,12 @@ jq --arg rpcUrl "$L2_GETH_URL" '.rpcUrl = $rpcUrl' secrets.json > secrets_update
 
 export RPC_URL="${L2_GETH_URL}"
 
+if [[ -n "$DEPLOYED_CONTRACT" ]]; then
+  echo "DEPLOYED_CONTRACT is set to '$DEPLOYED_CONTRACT'"
+  echo "Exiting without deploying contract"
+  exit 0
+fi
+
 # Check and exit if a deployment already exists (on restarts)
 if [ -f ./config.json ]; then
   echo "config.json already exists, checking the contract deployment"

--- a/app/data/config/watcher-mobymask-v2/deploy-and-generate-invite.sh
+++ b/app/data/config/watcher-mobymask-v2/deploy-and-generate-invite.sh
@@ -22,6 +22,7 @@ jq --arg rpcUrl "$L2_GETH_RPC" '.rpcUrl = $rpcUrl' secrets.json > secrets_update
 
 export RPC_URL="${L2_GETH_RPC}"
 
+# Check if DEPLOYED_CONTRACT environment variable set to skip contract deployment
 if [[ -n "$DEPLOYED_CONTRACT" ]]; then
   echo "DEPLOYED_CONTRACT is set to '$DEPLOYED_CONTRACT'"
   echo "Exiting without deploying contract"
@@ -46,7 +47,7 @@ if [ -f ./config.json ]; then
   fi
 fi
 
-# Wait until balance for deployer account is reflected
+# Wait until balance for deployer account is updated
 cd ../hardhat
 while true; do
   ACCOUNT_BALANCE=$(yarn balance --network optimism "$PRIVATE_KEY_DEPLOYER" | grep ETH)

--- a/app/data/config/watcher-mobymask-v2/mobymask-app-config.json
+++ b/app/data/config/watcher-mobymask-v2/mobymask-app-config.json
@@ -1,4 +1,5 @@
 {
+  "name": "MobyMask",
   "relayNodes": [
     "/ip4/127.0.0.1/tcp/9090/ws/p2p/12D3KooWSPCsVkHVyLQoCqhu2YRPvvM7o6r6NRYyLM5zeA6Uig5t"
   ],

--- a/app/data/config/watcher-mobymask-v2/mobymask-app-start.sh
+++ b/app/data/config/watcher-mobymask-v2/mobymask-app-start.sh
@@ -4,6 +4,7 @@ if [ -n "$CERC_SCRIPT_DEBUG" ]; then
   set -x
 fi
 
+# Use config from mounted volume if available (when running web-app along with watcher stack)
 if [ -f /server/config.json ]; then
   echo "Merging config for deployed contract from mounted volume"
   # Merging config files to get deployed contract address
@@ -11,6 +12,7 @@ if [ -f /server/config.json ]; then
 else
   echo "Setting deployed contract details from env"
 
+  # Set config values from environment variables
   jq --arg address "$DEPLOYED_CONTRACT" \
     --argjson chainId $CHAIN_ID \
     --argjson relayNodes "$RELAY_NODES" \

--- a/app/data/config/watcher-mobymask-v2/mobymask-app-start.sh
+++ b/app/data/config/watcher-mobymask-v2/mobymask-app-start.sh
@@ -14,10 +14,10 @@ else
   jq --arg address "$DEPLOYED_CONTRACT" \
     --argjson chainId $CHAIN_ID \
     --argjson relayNodes "$RELAY_NODES" \
-    '.address = $address | .chainId = $chainId | .relayNodes = $myArray' \
+    '.address = $address | .chainId = $chainId | .relayNodes = $relayNodes' \
     /app/src/mobymask-app-config.json > /app/src/config.json
 fi
 
-REACT_APP_WATCHER_URI="$WATCHER_URL_SCHEME://$WATCHER_HOST:$WATCHER_PORT/graphql" npm run build
+REACT_APP_WATCHER_URI="$APP_WATCHER_URL/graphql" npm run build
 
 serve -s build

--- a/app/data/config/watcher-mobymask-v2/mobymask-app-start.sh
+++ b/app/data/config/watcher-mobymask-v2/mobymask-app-start.sh
@@ -4,9 +4,20 @@ if [ -n "$CERC_SCRIPT_DEBUG" ]; then
   set -x
 fi
 
-# Merging config files to get deployed contract address
-jq -s '.[0] * .[1]' /app/src/mobymask-app-config.json /server/config.json > /app/src/config.json
+if [ -f /server/config.json ]; then
+  echo "Merging config for deployed contract from mounted volume"
+  # Merging config files to get deployed contract address
+  jq -s '.[0] * .[1]' /app/src/mobymask-app-config.json /server/config.json > /app/src/config.json
+else
+  echo "Setting deployed contract details from env"
 
-npm run build
+  jq --arg address "$DEPLOYED_CONTRACT" \
+    --argjson chainId $CHAIN_ID \
+    --argjson relayNodes "$RELAY_NODES" \
+    '.address = $address | .chainId = $chainId | .relayNodes = $myArray' \
+    /app/src/mobymask-app-config.json > /app/src/config.json
+fi
+
+REACT_APP_WATCHER_URI="$WATCHER_URL_SCHEME://$WATCHER_HOST:$WATCHER_PORT/graphql" npm run build
 
 serve -s build

--- a/app/data/config/watcher-mobymask-v2/mobymask-app.env
+++ b/app/data/config/watcher-mobymask-v2/mobymask-app.env
@@ -1,1 +1,0 @@
-REACT_APP_WATCHER_URI=http://localhost:3001/graphql

--- a/app/data/config/watcher-mobymask-v2/mobymask-params.env
+++ b/app/data/config/watcher-mobymask-v2/mobymask-params.env
@@ -1,6 +1,5 @@
 # Change if pointing web app to external watcher endpoint
 WATCHER_HOST="mobymask-watcher-server"
-WATCHER_HOST=localhost
 WATCHER_PORT=3001
 APP_WATCHER_URL="http://localhost:3001"
 

--- a/app/data/config/watcher-mobymask-v2/mobymask-params.env
+++ b/app/data/config/watcher-mobymask-v2/mobymask-params.env
@@ -7,5 +7,8 @@ APP_WATCHER_URL="http://localhost:3001"
 # mobymask-app will use this contract address in config if run separately
 DEPLOYED_CONTRACT=
 
+# Chain ID is used by mobymask web-app for txs
 CHAIN_ID=42069
+
+# Set relay nodes to be used by web-apps
 RELAY_NODES=["/ip4/127.0.0.1/tcp/9090/ws/p2p/12D3KooWSPCsVkHVyLQoCqhu2YRPvvM7o6r6NRYyLM5zeA6Uig5t"]

--- a/app/data/config/watcher-mobymask-v2/mobymask-params.env
+++ b/app/data/config/watcher-mobymask-v2/mobymask-params.env
@@ -1,7 +1,8 @@
 # Change if pointing web app to external watcher endpoint
-WATCHER_URL_SCHEME=http
+WATCHER_HOST="mobymask-watcher-server"
 WATCHER_HOST=localhost
 WATCHER_PORT=3001
+APP_WATCHER_URL="http://localhost:3001"
 
 # Set deployed MobyMask contract address to avoid deploying contract in stack
 # mobymask-app will use this contract address in config if run separately

--- a/app/data/config/watcher-mobymask-v2/mobymask-params.env
+++ b/app/data/config/watcher-mobymask-v2/mobymask-params.env
@@ -1,0 +1,11 @@
+# Change if pointing web app to external watcher endpoint
+WATCHER_URL_SCHEME=http
+WATCHER_HOST=localhost
+WATCHER_PORT=3001
+
+# Set deployed MobyMask contract address to avoid deploying contract in stack
+# mobymask-app will use this contract address in config if run separately
+DEPLOYED_CONTRACT=
+
+CHAIN_ID=42069
+RELAY_NODES=["/ip4/127.0.0.1/tcp/9090/ws/p2p/12D3KooWSPCsVkHVyLQoCqhu2YRPvvM7o6r6NRYyLM5zeA6Uig5t"]

--- a/app/data/config/watcher-mobymask-v2/optimism-params.env
+++ b/app/data/config/watcher-mobymask-v2/optimism-params.env
@@ -1,9 +1,10 @@
 # Change if pointing to an external optimism geth endpoint
 
 # L2 endpoints
-# TODO: Add another env for complete URL to handle https
+L2_GETH_RPC="http://op-geth:8545"
 L2_GETH_HOST="op-geth"
 L2_GETH_PORT=8545
+
 L2_NODE_HOST="op-node"
 L2_NODE_PORT=8547
 

--- a/app/data/config/watcher-mobymask-v2/start-server.sh
+++ b/app/data/config/watcher-mobymask-v2/start-server.sh
@@ -6,10 +6,11 @@ fi
 
 echo "Using L2 RPC endpoint ${L2_GETH_RPC}"
 
+# Use contract address from environment variable or set from config.json in mounted volume
 if [ -n "$DEPLOYED_CONTRACT" ]; then
   CONTRACT_ADDRESS="${DEPLOYED_CONTRACT}"
 else
-  # Assign deployed contract address from server config
+  # Assign deployed contract address from server config (created by mobymask container after deploying contract)
   CONTRACT_ADDRESS=$(jq -r '.address' /server/config.json | tr -d '"')
 fi
 
@@ -21,16 +22,18 @@ else
   echo "Using PRIVATE_KEY_PEER from env"
 fi
 
+# Set private key and contract address for watcher peer txs to L2 only if PRIVATE_KEY_PEER variable is set
 if [ -n "$PRIVATE_KEY_PEER" ]; then
-  # Read in the original TOML file and modify it
+  # Read in config template TOML file and modify it
   CONTENT=$(cat environments/watcher-config-template.toml)
   NEW_CONTENT=$(echo "$CONTENT" | sed -E "/\[metrics\]/i \\\n\n      [server.p2p.peer.l2TxConfig]\n        privateKey = \"${PRIVATE_KEY_PEER}\"\n        contractAddress = \"${CONTRACT_ADDRESS}\"\n")
 
-  # Write the modified content to a new file
+  # Write the modified content to a watcher config file
   echo "$NEW_CONTENT" > environments/local.toml
 
   sed -i 's|REPLACE_WITH_L2_GETH_RPC_ENDPOINT|'"${L2_GETH_RPC}"'|' environments/local.toml
 else
+  # Copy template config to watcher config without setting params for peer L2 txs
   cp environments/watcher-config-template.toml environments/local.toml
 fi
 

--- a/app/data/config/watcher-mobymask-v2/start-server.sh
+++ b/app/data/config/watcher-mobymask-v2/start-server.sh
@@ -4,6 +4,8 @@ if [ -n "$CERC_SCRIPT_DEBUG" ]; then
   set -x
 fi
 
+echo "Using L2 RPC endpoint ${L2_GETH_RPC}"
+
 # Assign deployed contract address from server config
 CONTRACT_ADDRESS=$(jq -r '.address' /server/config.json | tr -d '"')
 
@@ -17,9 +19,7 @@ fi
 
 sed "s/REPLACE_WITH_PRIVATE_KEY/${PRIVATE_KEY_PEER}/" environments/watcher-config-template.toml > environments/local.toml
 sed -i "s/REPLACE_WITH_CONTRACT_ADDRESS/${CONTRACT_ADDRESS}/" environments/local.toml
-
-export L2_GETH_URL="http://${L2_GETH_HOST}:${L2_GETH_PORT}"
-sed -i 's|REPLACE_WITH_L2_GETH_URL|'"${L2_GETH_URL}"'|' environments/local.toml
+sed -i 's|REPLACE_WITH_L2_GETH_RPC_ENDPOINT|'"${L2_GETH_RPC}"'|' environments/local.toml
 
 echo 'yarn server'
 yarn server

--- a/app/data/config/watcher-mobymask-v2/start-server.sh
+++ b/app/data/config/watcher-mobymask-v2/start-server.sh
@@ -34,7 +34,5 @@ else
   cp environments/watcher-config-template.toml environments/local.toml
 fi
 
-cat environments/local.toml
-
 echo 'yarn server'
 yarn server

--- a/app/data/config/watcher-mobymask-v2/test-app-start.sh
+++ b/app/data/config/watcher-mobymask-v2/test-app-start.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+if [ -n "$CERC_SCRIPT_DEBUG" ]; then
+  set -x
+fi
+
+
+jq --argjson relayNodes "$RELAY_NODES" \
+  '.relayNodes = $relayNodes' \
+  ./src/test-app-config.json > ./src/config.json
+
+yarn build
+
+serve -s build

--- a/app/data/config/watcher-mobymask-v2/test-app-start.sh
+++ b/app/data/config/watcher-mobymask-v2/test-app-start.sh
@@ -4,7 +4,7 @@ if [ -n "$CERC_SCRIPT_DEBUG" ]; then
   set -x
 fi
 
-
+# Set relay nodes in config from RELAY_NODES environment variable
 jq --argjson relayNodes "$RELAY_NODES" \
   '.relayNodes = $relayNodes' \
   ./src/test-app-config.json > ./src/config.json

--- a/app/data/config/watcher-mobymask-v2/watcher-config-template.toml
+++ b/app/data/config/watcher-mobymask-v2/watcher-config-template.toml
@@ -59,7 +59,7 @@
 [upstream]
   [upstream.ethServer]
     gqlApiEndpoint = "http://ipld-eth-server:8083/graphql"
-    rpcProviderEndpoint = "REPLACE_WITH_L2_GETH_URL"
+    rpcProviderEndpoint = "REPLACE_WITH_L2_GETH_RPC_ENDPOINT"
     blockDelayInMilliSecs = 60000
 
   [upstream.cache]

--- a/app/data/config/watcher-mobymask-v2/watcher-config-template.toml
+++ b/app/data/config/watcher-mobymask-v2/watcher-config-template.toml
@@ -36,10 +36,6 @@
       peerIdFile = './peer-id.json'
       enableDebugInfo = true
 
-      [server.p2p.peer.l2TxConfig]
-        privateKey = 'REPLACE_WITH_PRIVATE_KEY'
-        contractAddress = 'REPLACE_WITH_CONTRACT_ADDRESS'
-
 [metrics]
   host = "0.0.0.0"
   port = 9000

--- a/app/data/container-build/cerc-mobymask-ui/Dockerfile
+++ b/app/data/container-build/cerc-mobymask-ui/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18.15.0-alpine3.16
 
-RUN apk --update --no-cache add make git jq
+RUN apk --update --no-cache add make git jq bash
 
 WORKDIR /app
 

--- a/app/data/container-build/cerc-react-peer/Dockerfile
+++ b/app/data/container-build/cerc-react-peer/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18.15.0-alpine3.16
 
-RUN apk --update --no-cache add make git python3
+RUN apk --update --no-cache add make git python3 jq
 
 WORKDIR /app
 

--- a/app/data/stacks/mobymask-v2/mobymask-only.md
+++ b/app/data/stacks/mobymask-v2/mobymask-only.md
@@ -9,24 +9,15 @@ Prerequisite: L2 Optimism Geth and Node RPC endpoints
 Clone required repositories:
 
 ```bash
-laconic-so --stack mobymask-v2 setup-repositories --include cerc-io/MobyMask,cerc-io/watcher-ts,cerc-io/react-peer,cerc-io/mobymask-ui
+laconic-so --stack mobymask-v2 setup-repositories --include cerc-io/MobyMask,cerc-io/watcher-ts
 ```
 
 Checkout to the required versions and branches in repos:
 
 ```bash
-```bash
 # watcher-ts
 cd ~/cerc/watcher-ts
 git checkout v0.2.34
-
-# react-peer
-cd ~/cerc/react-peer
-git checkout v0.2.31
-
-# mobymask-ui
-cd ~/cerc/mobymask-ui
-git checkout laconic
 
 # MobyMask
 cd ~/cerc/MobyMask
@@ -36,20 +27,24 @@ git checkout v0.1.2
 Build the container images:
 
 ```bash
-laconic-so --stack mobymask-v2 build-containers --include cerc/watcher-mobymask-v2,cerc/react-peer,cerc/mobymask-ui,cerc/mobymask
+laconic-so --stack mobymask-v2 build-containers --include cerc/watcher-mobymask-v2,cerc/mobymask
 ```
 
 This should create the required docker images in the local image registry
 
 ## Deploy
 
-Update the [optimism-params.env](../../config/watcher-mobymask-v2/optimism-params.env) file with Optimism endpoints and other params if running Optimism separately
+### Configuration
 
+* In [mobymask-params.env](../../config/watcher-mobymask-v2/mobymask-params.env) file set `DEPLOYED_CONTRACT` to existing deployed mobymask contract address
+  * Setting `DEPLOYED_CONTRACT` will skip contract deployment when running stack
+* Update the [optimism-params.env](../../config/watcher-mobymask-v2/optimism-params.env) file with Optimism endpoints and other params for the Optimism running separately
+  * If `PRIVATE_KEY_PEER` is not set the inline watcher peer will not send txs to L2 on receiving P2P network messages
 * NOTE:
   * Stack Orchestrator needs to be run in [`dev`](/docs/CONTRIBUTING.md#install-developer-mode) mode to be able to edit the env file
   * If Optimism is running on the host machine, use `host.docker.internal` as the hostname to access the host port
 
-Deploy the stack:
+### Deploy the stack
 
 ```bash
 laconic-so --stack mobymask-v2 deploy --include watcher-mobymask-v2 up
@@ -67,7 +62,9 @@ docker ps
 docker logs -f <CONTAINER_ID>
 ```
 
-See [Tests](./README.md#tests) and [Demo](./README.md#demo) to interact with stack
+## Tests
+
+See [Tests](./README.md#tests)
 
 ## Clean up
 

--- a/app/data/stacks/mobymask-v2/mobymask-only.md
+++ b/app/data/stacks/mobymask-v2/mobymask-only.md
@@ -4,7 +4,7 @@ Instructions to setup and deploy MobyMask v2 watcher independently
 
 ## Setup
 
-Prerequisite: An L2 Optimism RPC endpoint
+Prerequisite: L2 Optimism Geth and Node RPC endpoints
 
 Clone required repositories:
 

--- a/app/data/stacks/mobymask-v2/stack.yml
+++ b/app/data/stacks/mobymask-v2/stack.yml
@@ -27,3 +27,5 @@ pods:
   - fixturenet-eth
   - fixturenet-optimism
   - watcher-mobymask-v2
+  - mobymask-app
+  - peer-test-app

--- a/app/data/stacks/mobymask-v2/web-apps.md
+++ b/app/data/stacks/mobymask-v2/web-apps.md
@@ -1,0 +1,91 @@
+# Web Apps
+
+Instructions to setup and deploy MobyMask and Peer Test web apps
+
+## Setup
+
+Prerequisite: Watcher with GQL and relay node endpoints
+
+Clone required repositories:
+
+```bash
+laconic-so --stack mobymask-v2 setup-repositories --include cerc-io/react-peer,cerc-io/mobymask-ui
+```
+
+Checkout to the required versions and branches in repos:
+
+```bash
+# react-peer
+cd ~/cerc/react-peer
+git checkout v0.2.31
+
+# mobymask-ui
+cd ~/cerc/mobymask-ui
+git checkout laconic
+```
+
+Build the container images:
+
+```bash
+laconic-so --stack mobymask-v2 build-containers --include cerc/react-peer-v2,cerc/mobymask-ui
+```
+
+This should create the required docker images in the local image registry
+
+## Deploy
+
+### Configuration
+
+* Update the [mobymask-params.env](../../config/watcher-mobymask-v2/mobymask-params.env) file with watcher endpoints and other params required by the web-apps
+  * `WATCHER_HOST` and `WATCHER_PORT` is used to check if watcher is up before building and deploying mobymask-app
+  * `APP_WATCHER_URL` is used by mobymask-app to make GQL queries
+  * `DEPLOYED_CONTRACT` and `CHAIN_ID` is used by mobymask-app in app config when creating messgaes for L2 txs
+  * `RELAY_NODES` is used by the web-apps to connect to the relay nodes (run in watcher)
+* NOTE:
+  * Stack Orchestrator needs to be run in [`dev`](/docs/CONTRIBUTING.md#install-developer-mode) mode to be able to edit the env file
+  * If watcher is running on the host machine, use `host.docker.internal` as the hostname to access the host port
+
+### Deploy the stack
+
+For running mobymask-app
+```bash
+laconic-so --stack mobymask-v2 deploy --include mobymask-app up
+```
+
+For running peer-test-app
+```bash
+laconic-so --stack mobymask-v2 deploy --include peer-test-app up
+```
+
+To list down and monitor the running containers:
+
+```bash
+docker ps
+
+# Check logs for a container
+docker logs -f <CONTAINER_ID>
+```
+
+## Clean up
+
+Stop all services running in the background:
+
+For mobymask-app
+```bash
+laconic-so --stack mobymask-v2 deploy --include mobymask-app down
+```
+
+For peer-test-app
+```bash
+laconic-so --stack mobymask-v2 deploy --include peer-test-app down
+```
+
+Clear volumes created by this stack:
+
+```bash
+# List all relevant volumes
+docker volume ls -q --filter "name=.*mobymask_deployment"
+
+# Remove all the listed volumes
+docker volume rm $(docker volume ls -q --filter "name=.*mobymask_deployment")
+```


### PR DESCRIPTION
Part of https://github.com/cerc-io/stack-orchestrator/issues/264

- Create separate pods for watcher and web-apps
- Support skipping contract deployment in mobymask watcher stack
- Make private key optional in watcher server for peer to avoid sending txs to L2 