### PR TITLE
Add env variable to enable/disable sending txs to L2 from watcher peer

### DIFF
--- a/app/data/config/watcher-mobymask-v2/deploy-and-generate-invite.sh
+++ b/app/data/config/watcher-mobymask-v2/deploy-and-generate-invite.sh
@@ -20,6 +20,9 @@ jq --arg privateKey "$PRIVATE_KEY_DEPLOYER" '.privateKey = $privateKey' secrets-
 # Set the RPC URL
 jq --arg rpcUrl "$L2_GETH_RPC" '.rpcUrl = $rpcUrl' secrets.json > secrets_updated.json && mv secrets_updated.json secrets.json
 
+# Set the MobyMask app base URI
+jq --arg baseURI "$MOBYMASK_APP_BASE_URI" '.baseURI = $baseURI' secrets.json > secrets_updated.json && mv secrets_updated.json secrets.json
+
 export RPC_URL="${L2_GETH_RPC}"
 
 # Check if DEPLOYED_CONTRACT environment variable set to skip contract deployment

--- a/app/data/config/watcher-mobymask-v2/mobymask-params.env
+++ b/app/data/config/watcher-mobymask-v2/mobymask-params.env
@@ -3,6 +3,12 @@ WATCHER_HOST="mobymask-watcher-server"
 WATCHER_PORT=3001
 APP_WATCHER_URL="http://localhost:3001"
 
+# Base URI for mobymask-app (used for generating invite)
+MOBYMASK_APP_BASE_URI="http://127.0.0.1:3002/#"
+
+# Set to false for disabling watcher peer to send txs to L2
+ENABLE_PEER_L2_TXS=true
+
 # Set deployed MobyMask contract address to avoid deploying contract in stack
 # mobymask-app will use this contract address in config if run separately
 DEPLOYED_CONTRACT=

--- a/app/data/config/watcher-mobymask-v2/secrets-template.json
+++ b/app/data/config/watcher-mobymask-v2/secrets-template.json
@@ -1,5 +1,5 @@
 {
     "rpcUrl": "",
     "privateKey": "",
-    "baseURI": "http://127.0.0.1:3002/#"
+    "baseURI": ""
 }

--- a/app/data/config/watcher-mobymask-v2/start-server.sh
+++ b/app/data/config/watcher-mobymask-v2/start-server.sh
@@ -22,20 +22,17 @@ else
   echo "Using PRIVATE_KEY_PEER from env"
 fi
 
-# Set private key and contract address for watcher peer txs to L2 only if PRIVATE_KEY_PEER variable is set
-if [ -n "$PRIVATE_KEY_PEER" ]; then
-  # Read in config template TOML file and modify it
-  CONTENT=$(cat environments/watcher-config-template.toml)
-  NEW_CONTENT=$(echo "$CONTENT" | sed -E "/\[metrics\]/i \\\n\n      [server.p2p.peer.l2TxConfig]\n        privateKey = \"${PRIVATE_KEY_PEER}\"\n        contractAddress = \"${CONTRACT_ADDRESS}\"\n")
 
-  # Write the modified content to a watcher config file
-  echo "$NEW_CONTENT" > environments/local.toml
+# Read in the config template TOML file and modify it
+WATCHER_CONFIG_TEMPLATE=$(cat environments/watcher-config-template.toml)
+WATCHER_CONFIG=$(echo "$WATCHER_CONFIG_TEMPLATE" | \
+  sed -E "s/REPLACE_WITH_ENABLE_PEER_L2_TXS/${ENABLE_PEER_L2_TXS}/g; \
+          s/REPLACE_WITH_PRIVATE_KEY_PEER/${PRIVATE_KEY_PEER}/g; \
+          s/REPLACE_WITH_CONTRACT_ADDRESS/${CONTRACT_ADDRESS}/g; \
+          s|REPLACE_WITH_L2_GETH_RPC_ENDPOINT|${L2_GETH_RPC}| ")
 
-  sed -i 's|REPLACE_WITH_L2_GETH_RPC_ENDPOINT|'"${L2_GETH_RPC}"'|' environments/local.toml
-else
-  # Copy template config to watcher config without setting params for peer L2 txs
-  cp environments/watcher-config-template.toml environments/local.toml
-fi
+# Write the modified content to a new file
+echo "$WATCHER_CONFIG" > environments/local.toml
 
 echo 'yarn server'
 yarn server

--- a/app/data/config/watcher-mobymask-v2/watcher-config-template.toml
+++ b/app/data/config/watcher-mobymask-v2/watcher-config-template.toml
@@ -35,6 +35,11 @@
       pubSubTopic = 'mobymask'
       peerIdFile = './peer-id.json'
       enableDebugInfo = true
+      enableL2Txs = REPLACE_WITH_ENABLE_PEER_L2_TXS
+
+      [server.p2p.peer.l2TxConfig]
+        privateKey = 'REPLACE_WITH_PRIVATE_KEY_PEER'
+        contractAddress = 'REPLACE_WITH_CONTRACT_ADDRESS'
 
 [metrics]
   host = "0.0.0.0"

--- a/app/data/config/watcher-mobymask-v2/watcher-config-template.toml
+++ b/app/data/config/watcher-mobymask-v2/watcher-config-template.toml
@@ -37,7 +37,7 @@
       enableDebugInfo = true
       enableL2Txs = REPLACE_WITH_ENABLE_PEER_L2_TXS
 
-      [server.p2p.peer.l2TxConfig]
+      [server.p2p.peer.l2TxsConfig]
         privateKey = 'REPLACE_WITH_PRIVATE_KEY_PEER'
         contractAddress = 'REPLACE_WITH_CONTRACT_ADDRESS'
 

--- a/app/data/stacks/mobymask-v2/README.md
+++ b/app/data/stacks/mobymask-v2/README.md
@@ -21,8 +21,7 @@ Checkout to the required versions and branches in repos
 ```bash
 # watcher-ts
 cd ~/cerc/watcher-ts
-# Update version after release
-git checkout v0.2.34
+git checkout v0.2.35
 
 # react-peer
 cd ~/cerc/react-peer

--- a/app/data/stacks/mobymask-v2/README.md
+++ b/app/data/stacks/mobymask-v2/README.md
@@ -21,6 +21,7 @@ Checkout to the required versions and branches in repos
 ```bash
 # watcher-ts
 cd ~/cerc/watcher-ts
+# Update version after release
 git checkout v0.2.34
 
 # react-peer

--- a/app/data/stacks/mobymask-v2/mobymask-only.md
+++ b/app/data/stacks/mobymask-v2/mobymask-only.md
@@ -17,8 +17,7 @@ Checkout to the required versions and branches in repos:
 ```bash
 # watcher-ts
 cd ~/cerc/watcher-ts
-# Update version after release
-git checkout v0.2.34
+git checkout v0.2.35
 
 # MobyMask
 cd ~/cerc/MobyMask

--- a/app/data/stacks/mobymask-v2/mobymask-only.md
+++ b/app/data/stacks/mobymask-v2/mobymask-only.md
@@ -17,6 +17,7 @@ Checkout to the required versions and branches in repos:
 ```bash
 # watcher-ts
 cd ~/cerc/watcher-ts
+# Update version after release
 git checkout v0.2.34
 
 # MobyMask
@@ -38,8 +39,9 @@ This should create the required docker images in the local image registry
 
 * In [mobymask-params.env](../../config/watcher-mobymask-v2/mobymask-params.env) file set `DEPLOYED_CONTRACT` to existing deployed mobymask contract address
   * Setting `DEPLOYED_CONTRACT` will skip contract deployment when running stack
+  * `ENABLE_PEER_L2_TXS` is used to enable/disable sending txs to L2 chain from watcher peer.
 * Update the [optimism-params.env](../../config/watcher-mobymask-v2/optimism-params.env) file with Optimism endpoints and other params for the Optimism running separately
-  * If `PRIVATE_KEY_PEER` is not set the inline watcher peer will not send txs to L2 on receiving P2P network messages
+  * `PRIVATE_KEY_PEER` is used by watcher peer to send txs to L2 chain
 * NOTE:
   * Stack Orchestrator needs to be run in [`dev`](/docs/CONTRIBUTING.md#install-developer-mode) mode to be able to edit the env file
   * If Optimism is running on the host machine, use `host.docker.internal` as the hostname to access the host port


### PR DESCRIPTION
Part of https://github.com/cerc-io/stack-orchestrator/issues/264

- Add flag to enable/disable watcher peer L2 txs
- Add env variable for setting mobymask-app base URI used in generating invite