### PR TITLE
Build lighthouse containers locally to get arm64 platform compatibility

### DIFF
--- a/app/data/container-build/cerc-fixturenet-eth-lighthouse/Dockerfile
+++ b/app/data/container-build/cerc-fixturenet-eth-lighthouse/Dockerfile
@@ -1,4 +1,4 @@
-FROM sigp/lcli:v3.2.1 AS lcli
+FROM cerc/lighthouse-lcli:local AS lcli
 FROM skylenet/ethereum-genesis-generator@sha256:210353ce7c898686bc5092f16c61220a76d357f51eff9c451e9ad1b9ad03d4d3 AS ethgen
 FROM cerc/fixturenet-eth-geth:local AS fnetgeth
 

--- a/app/data/container-build/cerc-lighthouse-base/build.sh
+++ b/app/data/container-build/cerc-lighthouse-base/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Build a local version of the sigp/lighthouse image
+docker build -t cerc/lighthouse-base:local -f ${CERC_REPO_BASE_DIR}/lighthouse/Dockerfile ${CERC_REPO_BASE_DIR}/lighthouse

--- a/app/data/container-build/cerc-lighthouse-lcli/build.sh
+++ b/app/data/container-build/cerc-lighthouse-lcli/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Build a local version of the sigp/lcli image
+docker build -t cerc/lighthouse-lcli:local -f ${CERC_REPO_BASE_DIR}/lighthouse/lcli/Dockerfile ${CERC_REPO_BASE_DIR}/lighthouse

--- a/app/data/container-build/cerc-lighthouse/Dockerfile
+++ b/app/data/container-build/cerc-lighthouse/Dockerfile
@@ -1,4 +1,4 @@
-FROM sigp/lighthouse:v3.2.1-modern
+FROM cerc/lighthouse-base:local
 
 RUN apt-get update; apt-get install bash netcat curl less jq -y;
 

--- a/app/data/container-image-list.txt
+++ b/app/data/container-image-list.txt
@@ -34,3 +34,5 @@ cerc/act-runner-task-executor
 cerc/optimism-l2geth
 cerc/optimism-op-batcher
 cerc/optimism-op-node
+cerc/lighthouse-base
+cerc/lighthouse-lcli

--- a/app/data/repository-list.txt
+++ b/app/data/repository-list.txt
@@ -28,3 +28,4 @@ lirewine/sdk
 telackey/act_runner
 ethereum-optimism/op-geth
 ethereum-optimism/optimism
+sigp/lighthouse

--- a/app/data/stacks/fixturenet-eth/stack.yml
+++ b/app/data/stacks/fixturenet-eth/stack.yml
@@ -3,9 +3,12 @@ name: fixturenet-eth
 decription: "Ethereum Fixturenet"
 repos:
   - cerc-io/go-ethereum
+  - sigp/lighthouse
   - dboreham/foundry
 containers:
   - cerc/go-ethereum
+  - cerc/lighthouse-base
+  - cerc/lighthouse-lcli
   - cerc/lighthouse
   - cerc/fixturenet-eth-geth
   - cerc/fixturenet-eth-lighthouse

--- a/app/data/stacks/fixturenet-eth/stack.yml
+++ b/app/data/stacks/fixturenet-eth/stack.yml
@@ -3,7 +3,7 @@ name: fixturenet-eth
 decription: "Ethereum Fixturenet"
 repos:
   - cerc-io/go-ethereum
-  - sigp/lighthouse
+  - cerc-io/lighthouse
   - dboreham/foundry
 containers:
   - cerc/go-ethereum


### PR DESCRIPTION
Not all the stacks have been updated yet in this PR. Also it takes a long time to build the lighthouse containers so it might be appropriate to merge this after we have image pull from gitea deployed.