### PR TITLE
Wait for transfer tx receipts when configuring Optimism

### DIFF
--- a/app/data/container-build/cerc-optimism-contracts/hardhat-tasks/send-balance.ts
+++ b/app/data/container-build/cerc-optimism-contracts/hardhat-tasks/send-balance.ts
@@ -16,7 +16,11 @@ task('send-balance', 'Sends Ether to a specified Ethereum account')
       to,
       value: ethers.utils.parseEther(amount),
     })
+    const txReceipt = await tx.wait()
 
     console.log(`Balance sent to: ${to}, from: ${wallet.address}`)
+    console.log(
+      `Block: { number: ${txReceipt.blockNumber}, hash: ${txReceipt.blockHash} }`
+    )
     console.log(`Transaction hash: ${tx.hash}`)
   })


### PR DESCRIPTION
Part of https://github.com/cerc-io/stack-orchestrator/issues/264

As part of L1 Optimism deployment, when we are doing a couple of balance transfers to the Bridge contract in [succession](https://github.com/cerc-io/stack-orchestrator/blob/main/app/data/config/fixturenet-optimism/optimism-contracts/run.sh#L122), sometimes the balance corresponding to the second transfer doesn't get reflected on L2.
Wait for the receipt when making the transfer tx for confirmation.