### PR TITLE
document the laconicd / sdk/ registry CLI / web console Stack

### DIFF
--- a/docs/laconicd-fixturenet.md
+++ b/docs/laconicd-fixturenet.md
@@ -72,7 +72,7 @@ It's possible to run into an `ESOCKETTIMEDOUT` error, e.g., `error An unexpected
 4. Set this environment variable to your droplet's IP address:
 
 ```
-export LACONIC_HOSTED_ENDPOINT=http://68.183.195.210
+export LACONIC_HOSTED_ENDPOINT=http://<your-IP>
 ```
 
 5. Deploy the stack:


### PR DESCRIPTION
- needs smoke testing & additional updates
- most (if not all) of the laconic-registry-cli commands mentioned at the end of the tutorial and found [here](https://github.com/cerc-io/laconic-registry-cli/blob/main/README.md) *should* work. The `--gas` and `--fees` flags can be omitted for sends/writes since this is now handled by an SO config file.
- on a local machine; requires modification of install instructions based on the user's knowledge of their machine, i.e., DON'T blindly run the install script locally. Replace `IP` with `localhost` and omit the line `export LACONIC_HOSTED_ENDPOINT=IP`
- this won't work on ARM / Apple Silicone, M1/M2