### PR TITLE
Upgrade Optimism

### DIFF
--- a/app/data/stacks/fixturenet-optimism/README.md
+++ b/app/data/stacks/fixturenet-optimism/README.md
@@ -19,7 +19,7 @@ Checkout to the required versions and branches in repos:
 ```bash
 # Optimism
 cd ~/cerc/optimism
-git checkout v1.0.3
+git checkout v1.0.4
 ```
 
 Build the container images:

--- a/app/data/stacks/fixturenet-optimism/l2-only.md
+++ b/app/data/stacks/fixturenet-optimism/l2-only.md
@@ -19,7 +19,7 @@ Checkout to the required versions and branches in repos:
 ```bash
 # Optimism
 cd ~/cerc/optimism
-git checkout v1.0.3
+git checkout v1.0.4
 ```
 
 Build the container images:

--- a/app/data/stacks/mobymask-v2/README.md
+++ b/app/data/stacks/mobymask-v2/README.md
@@ -35,7 +35,7 @@ git checkout v0.1.2
 
 # Optimism
 cd ~/cerc/optimism
-git checkout v1.0.3
+git checkout v1.0.4
 ```
 
 Build the container images:


### PR DESCRIPTION
Part of https://github.com/cerc-io/stack-orchestrator/issues/363

- Upgrade Optimism to `v1.0.4`