### PR TITLE
Add restart policies to fixturenet-eth and fixturenet-opimism stacks

### DIFF
--- a/app/data/compose/docker-compose-fixturenet-eth.yml
+++ b/app/data/compose/docker-compose-fixturenet-eth.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 services:
   fixturenet-eth-bootnode-geth:
+    restart: always
     hostname: fixturenet-eth-bootnode-geth
     env_file:
       - ../config/fixturenet-eth/fixturenet-eth.env
@@ -15,6 +16,7 @@ services:
       - "30303"
 
   fixturenet-eth-geth-1:
+    restart: always
     hostname: fixturenet-eth-geth-1
     cap_add:
       - SYS_PTRACE
@@ -42,6 +44,7 @@ services:
       - "6060"
 
   fixturenet-eth-geth-2:
+    restart: always
     hostname: fixturenet-eth-geth-2
     healthcheck:
       test: ["CMD", "nc", "-v", "localhost", "8545"]
@@ -60,12 +63,14 @@ services:
       - fixturenet_eth_geth_2_data:/root/ethdata
 
   fixturenet-eth-bootnode-lighthouse:
+    restart: always
     hostname: fixturenet-eth-bootnode-lighthouse
     environment:
       RUN_BOOTNODE: "true"
     image: cerc/fixturenet-eth-lighthouse:local
 
   fixturenet-eth-lighthouse-1:
+    restart: always
     hostname: fixturenet-eth-lighthouse-1
     healthcheck:
       test: ["CMD", "wget", "--tries=1", "--connect-timeout=1", "--quiet", "-O", "-", "http://localhost:8001/eth/v2/beacon/blocks/head"]
@@ -91,6 +96,7 @@ services:
       - "8001"
 
   fixturenet-eth-lighthouse-2:
+    restart: always
     hostname: fixturenet-eth-lighthouse-2
     healthcheck:
       test: ["CMD", "wget", "--tries=1", "--connect-timeout=1", "--quiet", "-O", "-", "http://localhost:8001/eth/v2/beacon/blocks/head"]

--- a/app/data/compose/docker-compose-fixturenet-optimism.yml
+++ b/app/data/compose/docker-compose-fixturenet-optimism.yml
@@ -5,6 +5,7 @@ services:
   # Creates / updates the configuration for L1 contracts deployment
   # Deploys the L1 smart contracts (outputs to volume l1_deployment)
   fixturenet-optimism-contracts:
+    restart: on-failure
     hostname: fixturenet-optimism-contracts
     image: cerc/optimism-contracts:local
     env_file:
@@ -35,6 +36,7 @@ services:
 
   # Generates the config files required for L2 (outputs to volume l2_config)
   op-node-l2-config-gen:
+    restart: on-failure
     image: cerc/optimism-op-node:local
     depends_on:
       fixturenet-optimism-contracts:
@@ -54,6 +56,7 @@ services:
 
   # Initializes and runs the L2 execution client  (outputs to volume l2_geth_data)
   op-geth:
+    restart: always
     image: cerc/optimism-l2geth:local
     depends_on:
       op-node-l2-config-gen:
@@ -76,6 +79,7 @@ services:
 
   # Runs the L2 consensus client (Sequencer node)
   op-node:
+    restart: always
     image: cerc/optimism-op-node:local
     depends_on:
       op-geth:
@@ -103,6 +107,7 @@ services:
 
   # Runs the batcher (takes transactions from the Sequencer and publishes them to L1)
   op-batcher:
+    restart: always
     image: cerc/optimism-op-batcher:local
     depends_on:
       op-node:
@@ -129,6 +134,7 @@ services:
 
   # Runs the proposer (periodically submits new state roots to L1)
   op-proposer:
+    restart: always
     image: cerc/optimism-op-proposer:local
     depends_on:
       op-node:

--- a/app/data/compose/docker-compose-foundry.yml
+++ b/app/data/compose/docker-compose-foundry.yml
@@ -1,6 +1,7 @@
 # Add-on pod to include foundry tooling within a fixturenet
 services:
   foundry:
+    restart: always
     image: cerc/foundry:local
     command: ["while :; do sleep 600; done"]
     volumes:

--- a/app/data/container-build/cerc-fixturenet-eth-lighthouse/genesis/cl/bootnode.sh
+++ b/app/data/container-build/cerc-fixturenet-eth-lighthouse/genesis/cl/bootnode.sh
@@ -13,21 +13,25 @@ DEBUG_LEVEL=${1:-info}
 
 echo "Starting bootnode"
 
-if [ ! -f "$DATADIR/bootnode/enr.dat" ]; then
-  echo "Generating bootnode enr"
-  lcli \
-    generate-bootnode-enr \
-    --ip $ENR_IP \
-    --udp-port $BOOTNODE_PORT \
-    --tcp-port $BOOTNODE_PORT \
-    --genesis-fork-version $GENESIS_FORK_VERSION \
-    --output-dir $DATADIR/bootnode
-
-  bootnode_enr=`cat $DATADIR/bootnode/enr.dat`
-  echo "- $bootnode_enr" > $TESTNET_DIR/boot_enr.yaml
-
-  echo "Generated bootnode enr and written to $TESTNET_DIR/boot_enr.yaml"
+# Clean up existing ENR dir to avoid node connectivity issues on a restart
+if [ -d "$DATADIR/bootnode" ]; then
+  echo "Removing existing bootnode enr directory"
+  rm -r "$DATADIR/bootnode"
 fi
+
+echo "Generating bootnode enr"
+lcli \
+  generate-bootnode-enr \
+  --ip $ENR_IP \
+  --udp-port $BOOTNODE_PORT \
+  --tcp-port $BOOTNODE_PORT \
+  --genesis-fork-version $GENESIS_FORK_VERSION \
+  --output-dir $DATADIR/bootnode
+
+bootnode_enr=`cat $DATADIR/bootnode/enr.dat`
+echo "- $bootnode_enr" > $TESTNET_DIR/boot_enr.yaml
+
+echo "Generated bootnode enr and written to $TESTNET_DIR/boot_enr.yaml"
 
 exec lighthouse boot_node \
     --testnet-dir $TESTNET_DIR \


### PR DESCRIPTION
Part of https://github.com/cerc-io/stack-orchestrator/issues/361

- Add restart policies to containers in `fixturenet-eth` and `fixturenet-opimism` stacks so a L1+L2 deployment restarts on it's own on a Docker daemon / system restart
- Remove existing lighthouse bootnode ENR directory to avoid node connectivity issues on a restart (will require rebuilding the image)