### PR TITLE
Possible cleanup of "Options" boilerplate

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http:#www.gnu.org/licenses/>.
 
 import click
+from dataclasses import dataclass
 
 from app import setup_repositories
 from app import build_containers
@@ -24,17 +25,15 @@ from app import version
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
-# TODO: this seems kind of weird and heavy on boilerplate -- check it is
-# the best Python can do for us.
-class Options(object):
-    def __init__(self, stack, quiet, verbose, dry_run, local_stack, debug, continue_on_error):
-        self.stack = stack
-        self.quiet = quiet
-        self.verbose = verbose
-        self.dry_run = dry_run
-        self.local_stack = local_stack
-        self.debug = debug
-        self.continue_on_error = continue_on_error
+@dataclass
+class Options:
+    stack: str
+    quiet: bool = False
+    verbose: bool = False
+    dry_run: bool = False
+    local_stack: bool = False
+    debug: bool = False
+    continue_on_error: bool = False
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)


### PR DESCRIPTION
Maybe this is a little cleaner using dataclasses?

The dataclass decorator is doing the same thing you are here with `__init__`, but also adds `__repr__` and `__eq__` by default.  The args can be passed positionally or as kwargs by default, with a kwargs only option.  The dataclass also allows for some nice things like setting defaults that would be challenging with regular classes.
re: https://docs.python.org/3/library/dataclasses.html

You can also get some features that might be desirable (_not used in this PR_), like fake immutability using the kwarg "frozen"
```
@dataclass(frozen=True)
class DataExample:
    foo: int
    bar: bool
    
>> ex = DataExample(4, True)
>> print(ex)
 DataExample(foo=4, bar=True)
 
>> ex.foo = 5
---------------------------------------------------------------------------
FrozenInstanceError                       Traceback (most recent call last)
Cell In[19], line 1
----> 1 ex.foo = 5

File <string>:4, in __setattr__(self, name, value)

FrozenInstanceError: cannot assign to field 'foo'
```