### PR TITLE
Add a plugeth-based version of the fixturenet

### DIFF
--- a/app/data/compose/docker-compose-fixturenet-plugeth.yml
+++ b/app/data/compose/docker-compose-fixturenet-plugeth.yml
@@ -1,0 +1,128 @@
+version: '3.7'
+
+services:
+  fixturenet-eth-bootnode-geth:
+    restart: always
+    hostname: fixturenet-eth-bootnode-geth
+    env_file:
+      - ../config/fixturenet-eth/fixturenet-eth.env
+    environment:
+      RUN_BOOTNODE: "true"
+    image: cerc/fixturenet-eth-plugeth:local
+    volumes:
+      - fixturenet_eth_bootnode_geth_data:/root/ethdata
+    ports:
+      - "9898"
+      - "30303"
+
+  fixturenet-eth-geth-1:
+    restart: always
+    hostname: fixturenet-eth-geth-1
+    cap_add:
+      - SYS_PTRACE
+    environment:
+      CERC_REMOTE_DEBUG: "true"
+      CERC_RUN_STATEDIFF: "detect"
+      CERC_STATEDIFF_DB_NODE_ID: 1
+      CERC_SCRIPT_DEBUG: ${CERC_SCRIPT_DEBUG}
+    env_file:
+      - ../config/fixturenet-eth/fixturenet-eth.env
+    image: cerc/fixturenet-eth-plugeth:local
+    volumes:
+      - fixturenet_eth_geth_1_data:/root/ethdata
+    healthcheck:
+      test: ["CMD", "nc", "-v", "localhost", "8545"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 3s
+    depends_on:
+      - fixturenet-eth-bootnode-geth
+    ports:
+      - "8545"
+      - "40000"
+      - "6060"
+
+  fixturenet-eth-geth-2:
+    restart: always
+    hostname: fixturenet-eth-geth-2
+    healthcheck:
+      test: ["CMD", "nc", "-v", "localhost", "8545"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 3s
+    environment:
+      CERC_KEEP_RUNNING_AFTER_GETH_EXIT: "true"
+    env_file:
+      - ../config/fixturenet-eth/fixturenet-eth.env
+    image: cerc/fixturenet-eth-plugeth:local
+    depends_on:
+      - fixturenet-eth-bootnode-geth
+    volumes:
+      - fixturenet_eth_geth_2_data:/root/ethdata
+
+  fixturenet-eth-bootnode-lighthouse:
+    restart: always
+    hostname: fixturenet-eth-bootnode-lighthouse
+    environment:
+      RUN_BOOTNODE: "true"
+    image: cerc/fixturenet-eth-lighthouse:local
+
+  fixturenet-eth-lighthouse-1:
+    restart: always
+    hostname: fixturenet-eth-lighthouse-1
+    healthcheck:
+      test: ["CMD", "wget", "--tries=1", "--connect-timeout=1", "--quiet", "-O", "-", "http://localhost:8001/eth/v2/beacon/blocks/head"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+    env_file:
+      - ../config/fixturenet-eth/fixturenet-eth.env
+    environment:
+      NODE_NUMBER: "1"
+      ETH1_ENDPOINT: "http://fixturenet-eth-geth-1:8545"
+      EXECUTION_ENDPOINT: "http://fixturenet-eth-geth-1:8551"
+    image: cerc/fixturenet-eth-lighthouse:local
+    volumes:
+      - fixturenet_eth_lighthouse_1_data:/opt/testnet/build/cl
+    depends_on:
+      fixturenet-eth-bootnode-lighthouse:
+        condition: service_started
+      fixturenet-eth-geth-1:
+        condition: service_healthy
+    ports:
+      - "8001"
+
+  fixturenet-eth-lighthouse-2:
+    restart: always
+    hostname: fixturenet-eth-lighthouse-2
+    healthcheck:
+      test: ["CMD", "wget", "--tries=1", "--connect-timeout=1", "--quiet", "-O", "-", "http://localhost:8001/eth/v2/beacon/blocks/head"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+    env_file:
+      - ../config/fixturenet-eth/fixturenet-eth.env
+    environment:
+      NODE_NUMBER: "2"
+      ETH1_ENDPOINT: "http://fixturenet-eth-geth-2:8545"
+      EXECUTION_ENDPOINT: "http://fixturenet-eth-geth-2:8551"
+      LIGHTHOUSE_GENESIS_STATE_URL: "http://fixturenet-eth-lighthouse-1:8001/eth/v2/debug/beacon/states/0"
+    image: cerc/fixturenet-eth-lighthouse:local
+    volumes:
+      - fixturenet_eth_lighthouse_2_data:/opt/testnet/build/cl
+    depends_on:
+      fixturenet-eth-bootnode-lighthouse:
+        condition: service_started
+      fixturenet-eth-geth-2:
+        condition: service_healthy
+
+volumes:
+  fixturenet_eth_bootnode_geth_data:
+  fixturenet_eth_geth_1_data:
+  fixturenet_eth_geth_2_data:
+  fixturenet_eth_lighthouse_1_data:
+  fixturenet_eth_lighthouse_2_data:

--- a/app/data/compose/docker-compose-fixturenet-plugeth.yml
+++ b/app/data/compose/docker-compose-fixturenet-plugeth.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   fixturenet-eth-bootnode-geth:
     restart: always
@@ -10,7 +8,8 @@ services:
       RUN_BOOTNODE: "true"
     image: cerc/fixturenet-eth-plugeth:local
     volumes:
-      - fixturenet_eth_bootnode_geth_data:/root/ethdata
+      - fixturenet_plugeth_bootnode_geth_data:/root/ethdata
+      - ../config/fixturenet-plugeth/plugins:/root/ethdata/plugins
     ports:
       - "9898"
       - "30303"
@@ -29,9 +28,10 @@ services:
       - ../config/fixturenet-eth/fixturenet-eth.env
     image: cerc/fixturenet-eth-plugeth:local
     volumes:
-      - fixturenet_eth_geth_1_data:/root/ethdata
+      - fixturenet_plugeth_geth_1_data:/root/ethdata
+      - ../config/fixturenet-plugeth/plugins:/root/ethdata/plugins
     healthcheck:
-      test: ["CMD", "nc", "-v", "localhost", "8545"]
+      test: ["CMD", "wget", "--tries=1", "--connect-timeout=1", "--quiet", "-O", "-", "http://localhost:8545/"]
       interval: 30s
       timeout: 10s
       retries: 10
@@ -47,7 +47,7 @@ services:
     restart: always
     hostname: fixturenet-eth-geth-2
     healthcheck:
-      test: ["CMD", "nc", "-v", "localhost", "8545"]
+      test: ["CMD", "wget", "--tries=1", "--connect-timeout=1", "--quiet", "-O", "-", "http://localhost:8545/"]
       interval: 30s
       timeout: 10s
       retries: 10
@@ -60,7 +60,8 @@ services:
     depends_on:
       - fixturenet-eth-bootnode-geth
     volumes:
-      - fixturenet_eth_geth_2_data:/root/ethdata
+      - fixturenet_plugeth_geth_2_data:/root/ethdata
+      - ../config/fixturenet-plugeth/plugins:/root/ethdata/plugins
 
   fixturenet-eth-bootnode-lighthouse:
     restart: always
@@ -86,7 +87,7 @@ services:
       EXECUTION_ENDPOINT: "http://fixturenet-eth-geth-1:8551"
     image: cerc/fixturenet-eth-lighthouse:local
     volumes:
-      - fixturenet_eth_lighthouse_1_data:/opt/testnet/build/cl
+      - fixturenet_plugeth_lighthouse_1_data:/opt/testnet/build/cl
     depends_on:
       fixturenet-eth-bootnode-lighthouse:
         condition: service_started
@@ -113,7 +114,7 @@ services:
       LIGHTHOUSE_GENESIS_STATE_URL: "http://fixturenet-eth-lighthouse-1:8001/eth/v2/debug/beacon/states/0"
     image: cerc/fixturenet-eth-lighthouse:local
     volumes:
-      - fixturenet_eth_lighthouse_2_data:/opt/testnet/build/cl
+      - fixturenet_plugeth_lighthouse_2_data:/opt/testnet/build/cl
     depends_on:
       fixturenet-eth-bootnode-lighthouse:
         condition: service_started
@@ -121,8 +122,8 @@ services:
         condition: service_healthy
 
 volumes:
-  fixturenet_eth_bootnode_geth_data:
-  fixturenet_eth_geth_1_data:
-  fixturenet_eth_geth_2_data:
-  fixturenet_eth_lighthouse_1_data:
-  fixturenet_eth_lighthouse_2_data:
+  fixturenet_plugeth_bootnode_geth_data:
+  fixturenet_plugeth_geth_1_data:
+  fixturenet_plugeth_geth_2_data:
+  fixturenet_plugeth_lighthouse_1_data:
+  fixturenet_plugeth_lighthouse_2_data:

--- a/app/data/config/fixturenet-plugeth/plugins/README.md
+++ b/app/data/config/fixturenet-plugeth/plugins/README.md
@@ -1,0 +1,1 @@
+See: https://docs.plugeth.org/

--- a/app/data/container-build/cerc-fixturenet-eth-plugeth/Dockerfile
+++ b/app/data/container-build/cerc-fixturenet-eth-plugeth/Dockerfile
@@ -1,19 +1,20 @@
 FROM skylenet/ethereum-genesis-generator@sha256:210353ce7c898686bc5092f16c61220a76d357f51eff9c451e9ad1b9ad03d4d3 AS ethgen
 
-# Using the same golang image as used to build geth: https://github.com/cerc-io/go-ethereum/blob/HEAD/Dockerfile
-FROM golang:1.18-alpine as delve
+FROM golang:1.19.4-bullseye AS delve
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
-FROM cerc/plugeth:local as geth
-
-FROM alpine:3.17
-RUN apk add --no-cache python3 python3-dev py3-pip curl wget jq build-base gettext libintl openssl bash bind-tools postgresql-client
+FROM ubuntu:22.04
+RUN apt-get update && \
+      apt-get install -y --no-install-recommends \
+        python3 python3-dev python3-pip curl wget jq gettext gettext-base openssl bash dnsutils postgresql-client make iproute2 netcat && \
+      rm -rf /var/lib/apt/lists/*
 
 COPY --from=delve  /go/bin/dlv /usr/local/bin/
 COPY --from=ethgen /usr/local/bin/eth2-testnet-genesis /usr/local/bin/
 COPY --from=ethgen /usr/local/bin/eth2-val-tools /usr/local/bin/
 COPY --from=ethgen /apps /apps
 
+RUN wget -O /usr/local/bin/geth https://github.com/openrelayxyz/plugeth/releases/download/v1.11.6.1.0/geth-linux-amd64-v1.1.0-v1.11.6.1.0 && chmod a+x /usr/local/bin/geth
 RUN cd /apps/el-gen && pip3 install -r requirements.txt
 
 COPY genesis /opt/testnet
@@ -21,7 +22,6 @@ COPY run-el.sh /opt/testnet/run.sh
 
 RUN cd /opt/testnet && make genesis-el
 
-COPY --from=geth  /usr/local/bin/geth /usr/local/bin/
 RUN geth --datadir ~/ethdata init /opt/testnet/build/el/geth.json && rm -f ~/ethdata/geth/nodekey
 
 ENTRYPOINT ["/opt/testnet/run.sh"]

--- a/app/data/container-build/cerc-fixturenet-eth-plugeth/Dockerfile
+++ b/app/data/container-build/cerc-fixturenet-eth-plugeth/Dockerfile
@@ -1,0 +1,27 @@
+FROM skylenet/ethereum-genesis-generator@sha256:210353ce7c898686bc5092f16c61220a76d357f51eff9c451e9ad1b9ad03d4d3 AS ethgen
+
+# Using the same golang image as used to build geth: https://github.com/cerc-io/go-ethereum/blob/HEAD/Dockerfile
+FROM golang:1.18-alpine as delve
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+FROM cerc/plugeth:local as geth
+
+FROM alpine:3.17
+RUN apk add --no-cache python3 python3-dev py3-pip curl wget jq build-base gettext libintl openssl bash bind-tools postgresql-client
+
+COPY --from=delve  /go/bin/dlv /usr/local/bin/
+COPY --from=ethgen /usr/local/bin/eth2-testnet-genesis /usr/local/bin/
+COPY --from=ethgen /usr/local/bin/eth2-val-tools /usr/local/bin/
+COPY --from=ethgen /apps /apps
+
+RUN cd /apps/el-gen && pip3 install -r requirements.txt
+
+COPY genesis /opt/testnet
+COPY run-el.sh /opt/testnet/run.sh
+
+RUN cd /opt/testnet && make genesis-el
+
+COPY --from=geth  /usr/local/bin/geth /usr/local/bin/
+RUN geth --datadir ~/ethdata init /opt/testnet/build/el/geth.json && rm -f ~/ethdata/geth/nodekey
+
+ENTRYPOINT ["/opt/testnet/run.sh"]

--- a/app/data/container-build/cerc-fixturenet-eth-plugeth/build.sh
+++ b/app/data/container-build/cerc-fixturenet-eth-plugeth/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Build cerc/fixturenet-eth-plugeth
+set -x
+
+source ${CERC_CONTAINER_BASE_DIR}/build-base.sh
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+if [ ! -d "${SCRIPT_DIR}/genesis" ]; then
+  cp -frp ${SCRIPT_DIR}/../cerc-fixturenet-eth-geth/genesis ${SCRIPT_DIR}/genesis
+fi
+
+if [ ! -d "${SCRIPT_DIR}/run-el.sh" ]; then
+  cp -fp ${SCRIPT_DIR}/../cerc-fixturenet-eth-geth/run-el.sh ${SCRIPT_DIR}/
+fi
+
+docker build -t cerc/fixturenet-eth-plugeth:local -f ${SCRIPT_DIR}/Dockerfile ${build_command_args} $SCRIPT_DIR

--- a/app/data/stacks/fixturenet-plugeth-tx/README.md
+++ b/app/data/stacks/fixturenet-plugeth-tx/README.md
@@ -1,0 +1,37 @@
+# fixturenet-eth-tx
+
+A variation of `fixturenet-eth` that automatically generates transactions using `tx-spammer`.
+
+See `stacks/fixturenet-eth/README.md` for more information.
+
+## Containers
+
+* cerc/go-ethereum
+* cerc/lighthouse
+* cerc/fixturenet-eth-geth
+* cerc/fixturenet-eth-lighthouse
+* cerc/tx-spammer
+
+## Deploy the stack
+```
+$ laconic-so --stack fixturenet-eth-tx setup-repositories
+$ laconic-so --stack fixturenet-eth-tx build-containers
+$ laconic-so --stack fixturenet-eth-tx deploy up
+```
+
+## Export the ethdb (optional)
+
+It is easy to export data from the fixturenet for offline processing of the raw ethdb files (eg, by eth-statediff-service) using the `export-ethdb.sh` script.
+
+For example:
+
+```
+$ app/data/container-build/cerc-fixturenet-eth-lighthouse/scripts/export-ethdb.sh 500
+Waiting for geth to generate DAG.... done
+Waiting for beacon phase0.... done
+Waiting for beacon altair.... done
+Waiting for beacon bellatrix pre-merge.... done
+Waiting for beacon bellatrix merge.... done
+Waiting for block number 500.... done
+Exporting ethdb.... ./ethdb.tgz
+```

--- a/app/data/stacks/fixturenet-plugeth-tx/README.md
+++ b/app/data/stacks/fixturenet-plugeth-tx/README.md
@@ -6,7 +6,6 @@ See `stacks/fixturenet-eth/README.md` for more information.
 
 ## Containers
 
-* cerc/plugeth
 * cerc/lighthouse
 * cerc/fixturenet-eth-plugeth
 * cerc/fixturenet-eth-lighthouse

--- a/app/data/stacks/fixturenet-plugeth-tx/README.md
+++ b/app/data/stacks/fixturenet-plugeth-tx/README.md
@@ -1,37 +1,20 @@
-# fixturenet-eth-tx
+# fixturenet-plugeth-tx
 
-A variation of `fixturenet-eth` that automatically generates transactions using `tx-spammer`.
+A variation of `fixturenet-eth` that uses `plugeth` instead of `go-ethereum`.
 
 See `stacks/fixturenet-eth/README.md` for more information.
 
 ## Containers
 
-* cerc/go-ethereum
+* cerc/plugeth
 * cerc/lighthouse
-* cerc/fixturenet-eth-geth
+* cerc/fixturenet-eth-plugeth
 * cerc/fixturenet-eth-lighthouse
 * cerc/tx-spammer
 
 ## Deploy the stack
 ```
-$ laconic-so --stack fixturenet-eth-tx setup-repositories
-$ laconic-so --stack fixturenet-eth-tx build-containers
-$ laconic-so --stack fixturenet-eth-tx deploy up
-```
-
-## Export the ethdb (optional)
-
-It is easy to export data from the fixturenet for offline processing of the raw ethdb files (eg, by eth-statediff-service) using the `export-ethdb.sh` script.
-
-For example:
-
-```
-$ app/data/container-build/cerc-fixturenet-eth-lighthouse/scripts/export-ethdb.sh 500
-Waiting for geth to generate DAG.... done
-Waiting for beacon phase0.... done
-Waiting for beacon altair.... done
-Waiting for beacon bellatrix pre-merge.... done
-Waiting for beacon bellatrix merge.... done
-Waiting for block number 500.... done
-Exporting ethdb.... ./ethdb.tgz
+$ laconic-so --stack fixturenet-plugeth-tx setup-repositories
+$ laconic-so --stack fixturenet-plugeth-tx build-containers
+$ laconic-so --stack fixturenet-plugeth-tx deploy up
 ```

--- a/app/data/stacks/fixturenet-plugeth-tx/stack.yml
+++ b/app/data/stacks/fixturenet-plugeth-tx/stack.yml
@@ -1,0 +1,15 @@
+version: "1.2"
+name: fixturenet-plugeth-tx
+decription: "plugeth Ethereum Fixturenet w/ tx-spammer"
+repos:
+  - github.com/openrelayxyz/plugeth
+  - github.com/cerc-io/tx-spammer
+containers:
+  - cerc/plugeth
+  - cerc/lighthouse
+  - cerc/fixturenet-eth-plugeth
+  - cerc/fixturenet-eth-lighthouse
+  - cerc/tx-spammer
+pods:
+  - fixturenet-plugeth
+  - tx-spammer

--- a/app/data/stacks/fixturenet-plugeth-tx/stack.yml
+++ b/app/data/stacks/fixturenet-plugeth-tx/stack.yml
@@ -2,10 +2,8 @@ version: "1.2"
 name: fixturenet-plugeth-tx
 decription: "plugeth Ethereum Fixturenet w/ tx-spammer"
 repos:
-  - github.com/openrelayxyz/plugeth
   - github.com/cerc-io/tx-spammer
 containers:
-  - cerc/plugeth
   - cerc/lighthouse
   - cerc/fixturenet-eth-plugeth
   - cerc/fixturenet-eth-lighthouse


### PR DESCRIPTION
```
$ laconic-so --stack fixturenet-plugeth-tx deploy-system up
WARN[0000] The "CERC_SCRIPT_DEBUG" variable is not set. Defaulting to a blank string.
[+] Running 7/7
 ✔ Container laconic-5b9fce81ce62bb05e4f5d057165a52ae-fixturenet-eth-bootnode-lighthouse-1  Running                                                                                                          0.0s
 ✔ Container laconic-5b9fce81ce62bb05e4f5d057165a52ae-fixturenet-eth-bootnode-geth-1        Running                                                                                                          0.0s
 ✔ Container laconic-5b9fce81ce62bb05e4f5d057165a52ae-fixturenet-eth-geth-1-1               Healthy                                                                                                          0.5s
 ✔ Container laconic-5b9fce81ce62bb05e4f5d057165a52ae-fixturenet-eth-geth-2-1               Healthy                                                                                                          0.5s
 ✔ Container laconic-5b9fce81ce62bb05e4f5d057165a52ae-tx-spammer-1                          Running                                                                                                          0.0s
 ✔ Container laconic-5b9fce81ce62bb05e4f5d057165a52ae-fixturenet-eth-lighthouse-2-1         Running                                                                                                          0.0s
 ✔ Container laconic-5b9fce81ce62bb05e4f5d057165a52ae-fixturenet-eth-lighthouse-1-1         Running                                                                                                          0.0s
```