### PR TITLE
Add stack for system tests.

### DIFF
--- a/app/data/stacks/fixturenet-eth-system-tests/README.md
+++ b/app/data/stacks/fixturenet-eth-system-tests/README.md
@@ -1,0 +1,3 @@
+# fixturenet-eth-system-tests
+
+A version of fixturenet-eth for use with https://git.vdb.to/cerc-io/system-tests

--- a/app/data/stacks/fixturenet-eth-system-tests/stack.yml
+++ b/app/data/stacks/fixturenet-eth-system-tests/stack.yml
@@ -1,0 +1,20 @@
+version: "1.0"
+name: fixturenet-eth-system-tests
+decription: "fixturenet-eth-system-tests"
+repos:
+  - github.com/cerc-io/go-ethereum
+  - github.com/cerc-io/ipld-eth-server
+  - github.com/cerc-io/ipld-eth-db
+  - github.com/cerc-io/lighthouse
+containers:
+  - cerc/go-ethereum
+  - cerc/lighthouse
+  - cerc/lighthouse-cli
+  - cerc/fixturenet-eth-geth
+  - cerc/fixturenet-eth-lighthouse
+  - cerc/ipld-eth-server
+  - cerc/ipld-eth-db
+pods:
+  - fixturenet-eth
+  - ipld-eth-server
+  - ipld-eth-db


### PR DESCRIPTION
This is in between the "loaded" fixturenet and the standard one, in that we need ipld-eth-server, ipld-eth-db, etc., but we do not need tx-spammer, keycloak, and so forth.