### PR TITLE
Cloud init scripts for user/dev mode

### DIFF
--- a/scripts/cloud-init-dev-mode-install.yaml
+++ b/scripts/cloud-init-dev-mode-install.yaml
@@ -1,7 +1,7 @@
 #cloud-config
 
-# Used for installing Stack Orchestrator on platforms that support `cloud-init`
-# Tested on Ubuntu
+# Used for easily testing stacks-in-development on cloud platforms
+# Assumes Ubuntu, edit the last line if targeting a different OS
 
 package_update: true
 package_upgrade: true
@@ -22,6 +22,8 @@ packages:
   - gnupg
   - lsb-release
   - unattended-upgrades
+  - python3.10-venv
+  - pip
 
 runcmd:
   - mkdir -p /etc/apt/keyrings
@@ -31,5 +33,4 @@ runcmd:
   - apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
   - systemctl enable docker
   - systemctl start docker
-  - curl -L -o /usr/local/bin/laconic-so https://github.com/cerc-io/stack-orchestrator/releases/latest/download/laconic-so
-  - chmod +x /usr/local/bin/laconic-so
+  - git clone https://github.com/cerc-io/stack-orchestrator.git /home/ubuntu/stack-orchestrator

--- a/scripts/cloud-init-dev-mode-install.yaml
+++ b/scripts/cloud-init-dev-mode-install.yaml
@@ -3,6 +3,14 @@
 # Used for easily testing stacks-in-development on cloud platforms
 # Assumes Ubuntu, edit the last line if targeting a different OS
 
+# Once SSH'd into the server, run:
+# `$ cd stack-orchestrator`
+# `$ git checkout <branch>
+# `$ ./scripts/developer-mode-setup.sh`
+# `$ source ./venv/bin/activate`
+
+# Followed by the stack instructions.
+
 package_update: true
 package_upgrade: true
 

--- a/scripts/cloud-init-user-mode-install.yaml
+++ b/scripts/cloud-init-user-mode-install.yaml
@@ -1,0 +1,32 @@
+#cloud-config
+
+package_update: true
+package_upgrade: true
+
+groups:
+  - docker
+
+system_info:
+  default_user:
+    groups: [ docker ]
+
+packages:
+  - apt-transport-https
+  - ca-certificates
+  - curl
+  - jq
+  - git
+  - gnupg
+  - lsb-release
+  - unattended-upgrades
+
+runcmd:
+  - mkdir -p /etc/apt/keyrings
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  - echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+  - apt-get update
+  - apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  - systemctl enable docker
+  - systemctl start docker
+  - curl -L -o /usr/local/bin/laconic-so https://github.com/cerc-io/stack-orchestrator/releases/latest/download/laconic-so
+  - chmod +x /usr/local/bin/laconic-so


### PR DESCRIPTION
- the user mode script is used in various places, having it here as the 'source of truth' made sense
- the dev mode script streamlines repeated testing of a stack in active development