### PR TITLE
Use cerc npm registry as default

### DIFF
--- a/app/base.py
+++ b/app/base.py
@@ -16,6 +16,7 @@
 import os
 from abc import ABC, abstractmethod
 from .deploy_system import get_stack_status
+from decouple import config
 
 
 def get_stack(config, stack):
@@ -69,3 +70,10 @@ class package_registry_stack(base_stack):
 
     def get_url(self):
         return self.url
+
+
+def get_npm_registry_url():
+    # If an auth token is not defined, we assume the default should be the cerc registry
+    # If an auth token is defined, we assume the local gitea should be used.
+    default_npm_registry_url = "http://gitea.local:3000/api/packages/cerc-io/npm/" if config("CERC_NPM_AUTH_TOKEN", default=None) else "https://git.vdb.to/api/packages/cerc-io/npm/"
+    return config("CERC_NPM_REGISTRY_URL", default=default_npm_registry_url)

--- a/app/build_containers.py
+++ b/app/build_containers.py
@@ -28,6 +28,7 @@ import click
 import importlib.resources
 from pathlib import Path
 from .util import include_exclude_check, get_parsed_stack_config
+from .base import get_npm_registry_url
 
 # TODO: find a place for this
 #    epilog="Config provided either in .env or settings.ini or env vars: CERC_REPO_BASE_DIR (defaults to ~/cerc)"
@@ -84,7 +85,7 @@ def command(ctx, include, exclude, force_rebuild, extra_build_args):
 
     # TODO: make this configurable
     container_build_env = {
-        "CERC_NPM_REGISTRY_URL": config("CERC_NPM_REGISTRY_URL", default="http://gitea.local:3000/api/packages/cerc-io/npm/"),
+        "CERC_NPM_REGISTRY_URL": get_npm_registry_url(),
         "CERC_NPM_AUTH_TOKEN": config("CERC_NPM_AUTH_TOKEN", default=""),
         "CERC_REPO_BASE_DIR": dev_root_path,
         "CERC_CONTAINER_BASE_DIR": container_build_dir,


### PR DESCRIPTION
When building containers that depend on npm packages, makes the user experience smoother because they don't need to set the npm repository url -- the cerc repository will be used by default.