### PR TITLE
Back to Github-based actions.

### DIFF
--- a/.gitea/workflows/fixturenet-eth-test.yml
+++ b/.gitea/workflows/fixturenet-eth-test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: "Clone project repository"
         uses: actions/checkout@v3
       - name: "Install Python"
-        uses: cerc-io/setup-python@v4
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
       - name: "Print Python version"

--- a/.gitea/workflows/publish.yml
+++ b/.gitea/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
           build_tag=$(./scripts/create_build_tag_file.sh)
           echo "build-tag=v${build_tag}" >> $GITHUB_OUTPUT
       - name: "Install Python"
-        uses: cerc-io/setup-python@v4
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
       - name: "Print Python version"
@@ -37,7 +37,7 @@ jobs:
         run: |
           cp ${{ steps.build.outputs.package-file }} ./laconic-so
       - name: "Create release"
-        uses: cerc-io/action-gh-release@gitea-v1
+        uses: actions/action-gh-release@gitea-v1
         with:
           tag_name: ${{ steps.build-info.outputs.build-tag }}
           # On the publish test branch, mark our release as a draft

--- a/.gitea/workflows/publish.yml
+++ b/.gitea/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           cp ${{ steps.build.outputs.package-file }} ./laconic-so
       - name: "Create release"
-        uses: https://gitea.com/cerc-io/action-gh-release@gitea-v1
+        uses: https://gitea.com/cerc-io/action-gh-release@gitea-v2
         with:
           tag_name: ${{ steps.build-info.outputs.build-tag }}
           # On the publish test branch, mark our release as a draft

--- a/.gitea/workflows/publish.yml
+++ b/.gitea/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           cp ${{ steps.build.outputs.package-file }} ./laconic-so
       - name: "Create release"
-        uses: actions/action-gh-release@gitea-v1
+        uses: https://gitea.com/cerc-io/action-gh-release@gitea-v1
         with:
           tag_name: ${{ steps.build-info.outputs.build-tag }}
           # On the publish test branch, mark our release as a draft

--- a/.gitea/workflows/test-deploy.yml
+++ b/.gitea/workflows/test-deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: "Clone project repository"
         uses: actions/checkout@v3
       - name: "Install Python"
-        uses: cerc-io/setup-python@v4
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
       - name: "Print Python version"

--- a/.gitea/workflows/test.yml
+++ b/.gitea/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: "Clone project repository"
         uses: actions/checkout@v3
       - name: "Install Python"
-        uses: cerc-io/setup-python@v4
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
       - name: "Print Python version"


### PR DESCRIPTION
Update for https://gitea.com/gitea/act_runner/commit/cf48ed88ba0400858feb40bffe7ec08ab37ef88b, where actions are pulled from github.com rather than gitea.com