### PR TITLE
WIP: update uniswap stack with ipld-eth-server

### DIFF
--- a/app/data/compose/docker-compose-watcher-uniswap-v3.yml
+++ b/app/data/compose/docker-compose-watcher-uniswap-v3.yml
@@ -75,6 +75,8 @@ services:
   uni-watcher-server:
     restart: unless-stopped
     depends_on:
+      ipld-eth-server:
+        condition: service_healthy
       uniswap-watcher-db:
         condition: service_healthy
       uni-watcher-job-runner:

--- a/app/data/config/watcher-uniswap-v3/erc20-watcher.toml
+++ b/app/data/config/watcher-uniswap-v3/erc20-watcher.toml
@@ -23,8 +23,8 @@
 
 [upstream]
   [upstream.ethServer]
-    gqlApiEndpoint = "http://ipld-eth-server:8083/graphql"
-    rpcProviderEndpoint = "http://ipld-eth-server:8082"
+    gqlApiEndpoint = "http://ipld-eth-server:8082/graphql"
+    rpcProviderEndpoint = "http://ipld-eth-server:8081"
 
   [upstream.cache]
     name = "requests"

--- a/app/data/config/watcher-uniswap-v3/erc20-watcher.toml
+++ b/app/data/config/watcher-uniswap-v3/erc20-watcher.toml
@@ -23,8 +23,8 @@
 
 [upstream]
   [upstream.ethServer]
-    gqlApiEndpoint = "http://ipld-eth-server.example.com:8083/graphql"
-    rpcProviderEndpoint = "http://ipld-eth-server.example.com:8082"
+    gqlApiEndpoint = "http://ipld-eth-server:8083/graphql"
+    rpcProviderEndpoint = "http://ipld-eth-server:8082"
 
   [upstream.cache]
     name = "requests"

--- a/app/data/config/watcher-uniswap-v3/uni-info-watcher.toml
+++ b/app/data/config/watcher-uniswap-v3/uni-info-watcher.toml
@@ -63,8 +63,8 @@
 
 [upstream]
   [upstream.ethServer]
-    gqlApiEndpoint = "http://ipld-eth-server.example.com:8083/graphql"
-    rpcProviderEndpoint = "http://ipld-eth-server.example.com:8082"
+    gqlApiEndpoint = "http://ipld-eth-server:8083/graphql"
+    rpcProviderEndpoint = "http://ipld-eth-server:8082"
 
   [upstream.cache]
     name = "requests"

--- a/app/data/config/watcher-uniswap-v3/uni-info-watcher.toml
+++ b/app/data/config/watcher-uniswap-v3/uni-info-watcher.toml
@@ -63,8 +63,8 @@
 
 [upstream]
   [upstream.ethServer]
-    gqlApiEndpoint = "http://ipld-eth-server:8083/graphql"
-    rpcProviderEndpoint = "http://ipld-eth-server:8082"
+    gqlApiEndpoint = "http://ipld-eth-server:8082/graphql"
+    rpcProviderEndpoint = "http://ipld-eth-server:8081"
 
   [upstream.cache]
     name = "requests"

--- a/app/data/config/watcher-uniswap-v3/uni-watcher.toml
+++ b/app/data/config/watcher-uniswap-v3/uni-watcher.toml
@@ -22,8 +22,8 @@
 
 [upstream]
   [upstream.ethServer]
-    gqlApiEndpoint = "http://ipld-eth-server:8083/graphql"
-    rpcProviderEndpoint = "http://ipld-eth-server:8082"
+    gqlApiEndpoint = "http://ipld-eth-server:8082/graphql"
+    rpcProviderEndpoint = "http://ipld-eth-server:8081"
 
   [upstream.cache]
     name = "requests"

--- a/app/data/config/watcher-uniswap-v3/uni-watcher.toml
+++ b/app/data/config/watcher-uniswap-v3/uni-watcher.toml
@@ -22,8 +22,8 @@
 
 [upstream]
   [upstream.ethServer]
-    gqlApiEndpoint = "http://ipld-eth-server.example.com:8083/graphql"
-    rpcProviderEndpoint = "http://ipld-eth-server.example.com:8082"
+    gqlApiEndpoint = "http://ipld-eth-server:8083/graphql"
+    rpcProviderEndpoint = "http://ipld-eth-server:8082"
 
   [upstream.cache]
     name = "requests"

--- a/app/data/stacks/uniswap-v3/README.md
+++ b/app/data/stacks/uniswap-v3/README.md
@@ -22,13 +22,13 @@ Instructions to deploy Uniswap v3 watcher stack (watcher + uniswap-v3-info front
 * Clone / pull required repositories:
 
   ```bash
-  $ laconic-so setup-repositories --include vulcanize/uniswap-watcher-ts,vulcanize/uniswap-v3-info --git-ssh --pull
+  $ laconic-so --stack uniswap-v3 setup-repositories
   ```
 
 * Build watcher and info app container images:
 
   ```bash
-  $ laconic-so build-containers --include cerc/watcher-uniswap-v3,cerc/uniswap-v3-info
+  $ laconic-so --stack uniswap-v3 build-containers
   ```
 
   This should create the required docker images in the local image registry.

--- a/app/data/stacks/uniswap-v3/stack.yml
+++ b/app/data/stacks/uniswap-v3/stack.yml
@@ -3,8 +3,14 @@ name: uniswap-v3
 repos:
   - github.com/vulcanize/uniswap-watcher-ts
   - github.com/vulcanize/uniswap-v3-info
+  - github.com/cerc-io/ipld-eth-db
+  - github.com/cerc-io/ipld-eth-server
 containers:
   - cerc/watcher-uniswap-v3
   - cerc/uniswap-v3-info
+  - cerc/ipld-eth-db
+    cerc/ipld-eth-server
 pods:
   - watcher-uniswap-v3
+  - ipld-eth-db
+  - ipld-eth-server

--- a/app/data/stacks/uniswap-v3/stack.yml
+++ b/app/data/stacks/uniswap-v3/stack.yml
@@ -9,7 +9,7 @@ containers:
   - cerc/watcher-uniswap-v3
   - cerc/uniswap-v3-info
   - cerc/ipld-eth-db
-    cerc/ipld-eth-server
+  - cerc/ipld-eth-server
 pods:
   - watcher-uniswap-v3
   - ipld-eth-db


### PR DESCRIPTION
currently fails like so:
```
# laconic-so --stack uniswap-v3 deploy up
[+] Running 11/11
 ✔ Network laconic-30b284773ec895b5a4601fcc6bd17780_default                          Cre...                                                            0.1s 
 ✔ Container laconic-30b284773ec895b5a4601fcc6bd17780-uniswap-watcher-db-1           Healthy                                                          53.0s 
 ✔ Container laconic-30b284773ec895b5a4601fcc6bd17780-ipld-eth-db-1                  Healthy                                                          31.3s 
 ✔ Container laconic-30b284773ec895b5a4601fcc6bd17780-erc20-watcher-server-1         Healthy                                                          53.0s 
 ✔ Container laconic-30b284773ec895b5a4601fcc6bd17780-uni-watcher-job-runner-1       Healthy                                                          41.7s 
 ✔ Container laconic-30b284773ec895b5a4601fcc6bd17780-migrations-1                   Started                                                          31.6s 
 ✔ Container laconic-30b284773ec895b5a4601fcc6bd17780-ipld-eth-server-1              Healthy                                                          52.1s 
 ✘ Container laconic-30b284773ec895b5a4601fcc6bd17780-uni-watcher-server-1           Error                                                           353.8s 
 ✔ Container laconic-30b284773ec895b5a4601fcc6bd17780-uni-info-watcher-job-runner-1  Created                                                           0.0s 
 ✔ Container laconic-30b284773ec895b5a4601fcc6bd17780-uni-info-watcher-server-1      Created                                                           0.0s 
 ✔ Container laconic-30b284773ec895b5a4601fcc6bd17780-uniswap-v3-info-1              Created                                                           0.0s
 ```
 
 looking at: `# docker logs laconic-30b284773ec895b5a4601fcc6bd17780-uni-watcher-job-runner-1` there's the clue:
 
```
2023-07-27T00:35:58.433Z vulcanize:job-runner Starting job runner...
2023-07-27T00:35:58.436Z vulcanize:metrics Metrics exposed at http://0.0.0.0:9000/metrics
2023-07-27T00:36:18.403Z vulcanize:job-queue Processing queue block-processing job 99ee9830-2c15-11ee-9af8-0bb6564ab21d...
2023-07-27T00:36:18.404Z vulcanize:common size:common#fetchBlocksAtHeight-prefetch-_blockAndEventsMap-size: 0
2023-07-27T00:36:18.446Z vulcanize:common common#cache-miss-12369621
time:eth-client#getBlocks-{"blockNumber":12369621}: 87.234ms
time:eth-client#getBlocks-{"blockNumber":12369628}: 70.899ms
time:eth-client#getBlocks-{"blockNumber":12369629}: 80.177ms
time:eth-client#getBlocks-{"blockNumber":12369622}: 97.556ms
time:eth-client#getBlocks-{"blockNumber":12369630}: 84.205ms
time:eth-client#getBlocks-{"blockNumber":12369627}: 95.676ms
time:eth-client#getBlocks-{"blockNumber":12369625}: 99.747ms
time:eth-client#getBlocks-{"blockNumber":12369623}: 107.078ms
time:eth-client#getBlocks-{"blockNumber":12369624}: 106.508ms
time:eth-client#getBlocks-{"blockNumber":12369626}: 103.295ms
time:common#fetchBatchBlocks-getBlocks: 168.341ms
2023-07-27T00:36:18.615Z vulcanize:common No blocks fetched for block number 12369621, retrying after 2000 ms delay.
```

I think the `Optional` step in the README is required with the correct heights. There also may be better ways to do this with the latest development of SO.