### PR TITLE
Force an old version of pydantic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ tqdm>=4.65.0
 python-on-whales>=0.64.0
 click>=8.1.6
 PyYAML>=6.0.1
-ruamel.yaml==0.17.32
-pydantic>=1.10.9
+ruamel.yaml>=0.17.32
+pydantic==1.10.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-on-whales>=0.64.0
 click>=8.1.6
 PyYAML>=6.0.1
 ruamel.yaml>=0.17.32
+pydantic>=1.10.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ tqdm>=4.65.0
 python-on-whales>=0.64.0
 click>=8.1.6
 PyYAML>=6.0.1
-ruamel.yaml>=0.17.32
+ruamel.yaml==0.17.32
 pydantic>=1.10.9


### PR DESCRIPTION
We need to ensure that the build uses version 1.x.x of pydantic because 2.x.x versions don't work now.