### PR TITLE
Add call to cleanup function

### DIFF
--- a/app/data/config/mainnet-eth/scripts/run-geth.sh
+++ b/app/data/config/mainnet-eth/scripts/run-geth.sh
@@ -23,6 +23,8 @@ cleanup() {
     echo "Done"
 }
 
+trap 'cleanup' SIGINT SIGTERM
+
 $START_CMD \
     --datadir="${CERC_ETH_DATADIR}" \
     --authrpc.addr="0.0.0.0" \


### PR DESCRIPTION
Looks like this got lost in translation from the fixturenet version.

Should fix: https://github.com/cerc-io/stack-orchestrator/issues/485