### PR TITLE
Restart support for fixturenet-lotus

### DIFF
--- a/app/data/compose/docker-compose-fixturenet-lotus.yml
+++ b/app/data/compose/docker-compose-fixturenet-lotus.yml
@@ -11,6 +11,7 @@ services:
       - ../config/fixturenet-lotus/fund-account.sh:/fund-account.sh
       - lotus_miner_params:/var/tmp/filecoin-proof-parameters
       - lotus-shared:/root/.lotus-shared
+      - lotus_miner_data:/root/data
     entrypoint: ["sh", "/docker-entrypoint-scripts.d/setup-miner.sh"]
     ports:
       - "1234"
@@ -30,6 +31,7 @@ services:
       - ../config/fixturenet-lotus/setup-node.sh:/docker-entrypoint-scripts.d/setup-node.sh
       - lotus_node_1_params:/var/tmp/filecoin-proof-parameters
       - lotus-shared:/root/.lotus-shared
+      - lotus_node_1_data:/root/data
     healthcheck:
       test: ["CMD", "nc", "-vz", "localhost", "1234"]
       interval: 30s
@@ -57,6 +59,7 @@ services:
       - ../config/fixturenet-lotus/setup-node.sh:/docker-entrypoint-scripts.d/setup-node.sh
       - lotus_node_2_params:/var/tmp/filecoin-proof-parameters
       - lotus-shared:/root/.lotus-shared
+      - lotus_node_2_data:/root/data
     healthcheck:
       test: ["CMD", "nc", "-vz", "localhost", "1234"]
       interval: 30s
@@ -77,3 +80,6 @@ volumes:
   lotus_node_1_params:
   lotus_node_2_params:
   lotus-shared:
+  lotus_miner_data:
+  lotus_node_1_data:
+  lotus_node_2_data:

--- a/app/data/config/fixturenet-lotus/lotus-env.env
+++ b/app/data/config/fixturenet-lotus/lotus-env.env
@@ -1,5 +1,5 @@
-LOTUS_PATH=/root/.lotus-local-net
-LOTUS_MINER_PATH=/root/.lotus-miner-local-net
+LOTUS_PATH=/root/data/.lotus-local-net
+LOTUS_MINER_PATH=/root/data/.lotus-miner-local-net
 LOTUS_SKIP_GENESIS_CHECK=_yes_
 LOTUS_FEVM_ENABLEETHRPC=true
 CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"

--- a/app/data/config/fixturenet-lotus/setup-miner.sh
+++ b/app/data/config/fixturenet-lotus/setup-miner.sh
@@ -18,8 +18,8 @@ fi
 # if genesis is not already setup
 if [ ! -f /root/data/localnet.json ]; then
   lotus-seed --sector-dir /root/data/.genesis-sectors pre-seal --sector-size 2KiB --num-sectors 2
-  lotus-seed --sector-dir /root/data/ genesis new /root/data/localnet.json
-  lotus-seed --sector-dir /root/data/ genesis add-miner /root/data/localnet.json /root/data/.genesis-sectors/pre-seal-t01000.json
+  lotus-seed --sector-dir /root/data/.genesis-sectors genesis new /root/data/localnet.json
+  lotus-seed --sector-dir /root/data/.genesis-sectors genesis add-miner /root/data/localnet.json /root/data/.genesis-sectors/pre-seal-t01000.json
 fi
 
 # start daemon

--- a/app/data/config/fixturenet-lotus/setup-miner.sh
+++ b/app/data/config/fixturenet-lotus/setup-miner.sh
@@ -33,8 +33,7 @@ echo "Daemon started."
 cp /devgen.car /root/.lotus-shared
 
 # publish bootnode peer info to shared volume
-# TODO: Improve exporting public address to shared volume
-lotus net listen | awk 'NR==4{print}' > /root/.lotus-shared/miner.addr
+lotus net listen | grep "$(ip addr | grep inet | grep -v '127.0.0.1' | sort | head -1 | awk '{print $2}' | cut -d '/' -f1)" | head -1 > /root/.lotus-shared/miner.addr
 
 # if miner not already initialized
 if [ ! -d $LOTUS_MINER_PATH ]; then

--- a/app/data/config/fixturenet-lotus/setup-miner.sh
+++ b/app/data/config/fixturenet-lotus/setup-miner.sh
@@ -15,12 +15,16 @@ else
   echo "Existing proof params found"
 fi
 
-lotus-seed pre-seal --sector-size 2KiB --num-sectors 2
-lotus-seed genesis new localnet.json
-lotus-seed genesis add-miner localnet.json ~/.genesis-sectors/pre-seal-t01000.json
+# if genesis is not already setup
+if [ ! -f /root/data/localnet.json ]; then
+  lotus-seed --sector-dir /root/data/.genesis-sectors pre-seal --sector-size 2KiB --num-sectors 2
+  lotus-seed --sector-dir /root/data/ genesis new /root/data/localnet.json
+  lotus-seed --sector-dir /root/data/ genesis add-miner /root/data/localnet.json /root/data/.genesis-sectors/pre-seal-t01000.json
+fi
 
 # start daemon
-nohup lotus daemon --lotus-make-genesis=devgen.car --profile=bootstrapper --genesis-template=localnet.json --bootstrap=false > /var/log/lotus.log 2>&1 &
+# /root/.lotus-shared/devgen.car path
+nohup lotus daemon --lotus-make-genesis=/root/.lotus-shared/devgen.car --profile=bootstrapper --genesis-template=/root/data/localnet.json --bootstrap=false > /var/log/lotus.log 2>&1 &
 
 # Loop until the daemon is started
 echo "Waiting for daemon to start..."
@@ -29,21 +33,18 @@ while ! grep -q "started ChainNotify channel" /var/log/lotus.log ; do
 done
 echo "Daemon started."
 
-# copy genesis file to shared volume
-cp /devgen.car /root/.lotus-shared
-
 # publish bootnode peer info to shared volume
 lotus net listen | grep "$(ip addr | grep inet | grep -v '127.0.0.1' | sort | head -1 | awk '{print $2}' | cut -d '/' -f1)" | head -1 > /root/.lotus-shared/miner.addr
 
 # if miner not already initialized
 if [ ! -d $LOTUS_MINER_PATH ]; then
   # initialize miner
-  lotus wallet import --as-default ~/.genesis-sectors/pre-seal-t01000.key
+  lotus wallet import --as-default /root/data/.genesis-sectors/pre-seal-t01000.key
 
   # fund a known account for usage
   /fund-account.sh
 
-  lotus-miner init --genesis-miner --actor=t01000 --sector-size=2KiB --pre-sealed-sectors=~/.genesis-sectors --pre-sealed-metadata=~/.genesis-sectors/pre-seal-t01000.json --nosync
+  lotus-miner init --genesis-miner --actor=t01000 --sector-size=2KiB --pre-sealed-sectors=/root/data/.genesis-sectors --pre-sealed-metadata=/root/data/.genesis-sectors/pre-seal-t01000.json --nosync
 fi
 
 # start miner

--- a/app/data/config/fixturenet-lotus/setup-node.sh
+++ b/app/data/config/fixturenet-lotus/setup-node.sh
@@ -9,20 +9,17 @@ while [ ! -f /root/.lotus-shared/miner.addr ]; do
 done
 echo "Resuming..."
 
-# if not already initialized
-if [ ! -f $LOTUS_PATH/config.toml ]; then
-  # init node config
-  mkdir $LOTUS_PATH
-  lotus config default > $LOTUS_PATH/config.toml
+# init node config
+mkdir -p $LOTUS_PATH
+lotus config default > $LOTUS_PATH/config.toml
 
-  # add bootstrap peer info if available
-  if [ -f /root/.lotus-shared/miner.addr ]; then
-    MINER_ADDR=\"$(cat /root/.lotus-shared/miner.addr)\"
-    # add bootstrap peer id to config file
-    sed -i "/^\[Libp2p\]/a \ \ BootstrapPeers = [$MINER_ADDR]" $LOTUS_PATH/config.toml
-  else
-    echo "Bootstrap peer info not found, unable to configure. Manual peering will be required."
-  fi
+# add bootstrap peer info if available
+if [ -f /root/.lotus-shared/miner.addr ]; then
+  MINER_ADDR=\"$(cat /root/.lotus-shared/miner.addr)\"
+  # add bootstrap peer id to config file
+  sed -i "/^\[Libp2p\]/a \ \ BootstrapPeers = [$MINER_ADDR]" $LOTUS_PATH/config.toml
+else
+  echo "Bootstrap peer info not found, unable to configure. Manual peering will be required."
 fi
 
 # start node

--- a/app/data/container-build/cerc-lotus/Dockerfile
+++ b/app/data/container-build/cerc-lotus/Dockerfile
@@ -99,7 +99,7 @@ CMD ["-help"]
 FROM lotus-base AS lotus-all-in-one
 
 # Install netcat for healthcheck
-RUN apt-get update && apt-get install -y netcat
+RUN apt-get update && apt-get install -y netcat && apt-get install -y iproute2
 
 ENV FILECOIN_PARAMETER_CACHE /var/tmp/filecoin-proof-parameters
 ENV LOTUS_MINER_PATH /var/lib/lotus-miner

--- a/app/data/stacks/azimuth/README.md
+++ b/app/data/stacks/azimuth/README.md
@@ -55,7 +55,7 @@ This should create the required docker images in the local image registry.
 
 ## Clean up
 
-Stop all the services running in background run:
+Stop all the services running in background:
 
 ```bash
 laconic-so --stack azimuth deploy-system down

--- a/app/data/stacks/fixturenet-lotus/README.md
+++ b/app/data/stacks/fixturenet-lotus/README.md
@@ -14,6 +14,9 @@ $ laconic-so --stack fixturenet-lotus build-containers
 ```
 $ laconic-so --stack fixturenet-lotus deploy --cluster lotus up
 ```
+
+Note: When running for the first time (or after clean up), the services will take some time to start properly as the Lotus nodes download the proof params (which are persisted to volumes)
+
 Correct operation should be verified by checking the container logs with:
 ```
 $ laconic-so --stack fixturenet-lotus deploy --cluster lotus logs lotus-miner
@@ -25,4 +28,20 @@ or by checking the chain status on each node:
 $ laconic-so --stack fixturenet-lotus deploy --cluster lotus exec lotus-miner "lotus status"
 $ laconic-so --stack fixturenet-lotus deploy --cluster lotus exec lotus-node-1 "lotus status"
 $ laconic-so --stack fixturenet-lotus deploy --cluster lotus exec lotus-node-2 "lotus status"
+```
+
+## 4. Clean up
+
+Stop all the services running in background:
+```
+$ laconic-so --stack fixturenet-lotus deploy --cluster lotus down
+```
+
+Clear volumes created by this stack:
+```
+# List all relevant volumes
+$ docker volume ls -q --filter "name=lotus"
+
+# Remove all the listed volumes
+$ docker volume rm $(docker volume ls -q --filter "name=lotus")
 ```

--- a/app/data/stacks/mobymask-v2/README.md
+++ b/app/data/stacks/mobymask-v2/README.md
@@ -93,7 +93,7 @@ Follow the [demo](./demo.md) to try out the MobyMask app with L2 chain
 
 ## Clean up
 
-Stop all the services running in background run:
+Stop all the services running in background:
 
 ```bash
 laconic-so --stack mobymask-v2 deploy --cluster mobymask_v2 down 30

--- a/app/data/stacks/sushiswap/README.md
+++ b/app/data/stacks/sushiswap/README.md
@@ -22,13 +22,15 @@ Deploy the stack:
 laconic-so --stack sushiswap deploy --cluster sushiswap up
 ```
 
+Note: When running for the first time (or after clean up), the services will take some time to start as Lotus nodes in the fixturenet download the proof params
+
 ## Tests
 
 Follow [smoke-tests.md](./smoke-tests.md) to run smoke tests
 
 ## Clean up
 
-Stop all the services running in background run:
+Stop all the services running in background:
 
 ```bash
 laconic-so --stack sushiswap deploy --cluster sushiswap down


### PR DESCRIPTION
Part of https://github.com/cerc-io/stack-orchestrator/issues/495

- Use `ip` utility to get the required miner node multiaddr (needs rebuilding local `cerc/lotus` image)
- Persist data to volumes to support restarts