### PR TITLE
[WIP] Upgrade mobymask v2 app versions

### DIFF
--- a/app/data/compose/docker-compose-mobymask-app.yml
+++ b/app/data/compose/docker-compose-mobymask-app.yml
@@ -14,7 +14,7 @@ services:
       CERC_APP_WATCHER_URL: ${CERC_APP_WATCHER_URL}
       CERC_RELAY_NODES: ${CERC_RELAY_NODES}
       CERC_DENY_MULTIADDRS: ${CERC_DENY_MULTIADDRS}
-      CERC_RELEASE: "v0.1.5"
+      CERC_RELEASE: "v0.1.6"
       CERC_USE_NPM: true
       CERC_CONFIG_FILE: "src/config.json"
     working_dir: /scripts
@@ -48,7 +48,7 @@ services:
       CERC_APP_WATCHER_URL: ${CERC_APP_WATCHER_URL}
       CERC_RELAY_NODES: ${CERC_RELAY_NODES}
       CERC_DENY_MULTIADDRS: ${CERC_DENY_MULTIADDRS}
-      CERC_RELEASE: "v0.1.5-lxdao-0.1.1"
+      CERC_RELEASE: "v0.1.6-lxdao-0.1.1"
       CERC_USE_NPM: false
       CERC_CONFIG_FILE: "src/utils/config.json"
     working_dir: /scripts

--- a/app/data/stacks/mobymask-v2/web-apps.md
+++ b/app/data/stacks/mobymask-v2/web-apps.md
@@ -6,6 +6,12 @@ Instructions to setup and deploy MobyMask and Peer Test web apps
 
 Prerequisite: Watcher with GQL and relay node endpoints
 
+Clone required repositories:
+
+```bash
+laconic-so --stack mobymask-v2 setup-repositories --include github.com/cerc-io/mobymask-ui
+```
+
 Build the container images:
 
 ```bash


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/406

- Upgrade to mobymask app version with fixed dependency issue