### PR TITLE
Include all of app/data regardless of depth.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,7 @@ setup(
     install_requires=[requirements],
     python_requires='>=3.7',
     include_package_data=True,
-    # See: https://github.com/pypa/setuptools/issues/1806
-    package_data={'': ['data/*', 'data/*/*', 'data/*/*/*', 'data/*/*/*/*', 'data/*/*/*/*/*']},
+    package_data={'': ['data/**']},
     classifiers=[
         "Programming Language :: Python :: 3.8",
         "Operating System :: OS Independent",


### PR DESCRIPTION
This fixes a bug where very deep paths were being excluded from the shiv package.

It appears the original version was a workaround for an issue with recursive globbing, but they issue was fixed over a year ago: https://github.com/pypa/setuptools/pull/3309