### PR TITLE
WIP: Test deploying gitea and publishing an npm package to it

### DIFF
--- a/.gitea/workflows/gitea.yml
+++ b/.gitea/workflows/gitea.yml
@@ -1,0 +1,49 @@
+name: Test Gitea
+
+on:
+  pull_request:
+    branches: '*'
+  push:
+    branches:
+      - main
+      - zach-test
+      - new-gitea-test
+
+# Needed until we can incorporate docker startup into the executor container
+env:
+  DOCKER_HOST: unix:///var/run/dind.sock
+
+jobs:
+  test:
+    name: "Run Gitea package registry test"
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Update'
+        run: apt-get update
+      - name: 'Setup jq'
+        run: apt-get install jq -y
+      - name: 'Check jq'
+        run: |
+          which jq
+          jq --version
+      - name: "Clone project repository"
+        uses: actions/checkout@v3
+      - name: "Install Python"
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: "Print Python version"
+        run: python3 --version
+      - name: "Install shiv"
+        run: pip install shiv
+      - name: "Generate build version file"
+        run: ./scripts/create_build_tag_file.sh
+      - name: "Build local shiv package"
+        run: ./scripts/build_shiv_package.sh
+      - name: Start dockerd # Also needed until we can incorporate into the executor
+        run: |
+          dockerd -H $DOCKER_HOST --userland-proxy=false &
+          sleep 5
+      - name: "Run gitea tests"
+        run: ./tests/gitea/test.sh
+

--- a/.github/workflows/gitea.yml
+++ b/.github/workflows/gitea.yml
@@ -1,0 +1,29 @@
+name: Gitea Test
+
+on:
+  pull_request:
+    branches: '*'
+  push:
+    branches: '*'
+
+jobs:
+  test:
+    name: "Run basic test suite"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Clone project repository"
+        uses: actions/checkout@v3
+      - name: "Install Python"
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: "Print Python version"
+        run: python3 --version
+      - name: "Install shiv"
+        run: pip install shiv
+      - name: "Generate build version file"
+        run: ./scripts/create_build_tag_file.sh
+      - name: "Build local shiv package"
+        run: ./scripts/build_shiv_package.sh
+      - name: "Run gitea tests"
+        run: ./tests/gitea/test.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Stack Orchestrator
 
+test
+
 Stack Orchestrator allows building and deployment of a Laconic Stack on a single machine with minimial prerequisites. It is a Python3 CLI tool that runs on any OS with Python3 and Docker. The following diagram summarizes the relevant repositories in the Laconic Stack - and the relationship to Stack Orchestrator.
 
 ![The Stack](/docs/images/laconic-stack.png)

--- a/app/build_npms.py
+++ b/app/build_npms.py
@@ -132,8 +132,8 @@ def command(ctx, include, exclude, force_rebuild, extra_build_args):
             try:
                 docker.run(builder_js_image_name,
                            remove=True,
-                           interactive=True,
-                           tty=True,
+                           interactive=False,
+                           tty=False,
                            user=f"{os.getuid()}:{os.getgid()}",
                            envs=envs,
                            # TODO: detect this host name in npm_registry_url rather than hard-wiring it

--- a/tests/gitea/test.sh
+++ b/tests/gitea/test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+if [ -n "$CERC_SCRIPT_DEBUG" ]; then
+  set -x
+fi
+# Dump environment variables for debugging
+echo "Environment variables:"
+env
+echo "Running gitea test"
+# Bit of a hack, test the most recent package
+TEST_TARGET_SO=$( ls -t1 ./package/laconic-so* | head -1 )
+# Set a non-default repo dir
+export CERC_REPO_BASE_DIR=~/stack-orchestrator-gitea-test
+echo "Testing this package: $TEST_TARGET_SO"
+echo "Test version command"
+reported_version_string=$( $TEST_TARGET_SO version )
+echo "Version reported is: ${reported_version_string}"
+echo "Cloning repositories into: $CERC_REPO_BASE_DIR"
+rm -rf $CERC_REPO_BASE_DIR
+mkdir -p $CERC_REPO_BASE_DIR
+
+$TEST_TARGET_SO --stack build-support build-containers
+$TEST_TARGET_SO --stack package-registry setup-repositories
+$TEST_TARGET_SO --stack package-registry build-containers
+output=$($TEST_TARGET_SO --stack package-registry deploy-system up)
+token=$(echo $output | grep -o 'export CERC_NPM_AUTH_TOKEN=[^ ]*' | cut -d '=' -f 2)
+export CERC_NPM_AUTH_TOKEN=$token
+$TEST_TARGET_SO --stack fixturenet-laconicd setup-repositories 
+$TEST_TARGET_SO --stack fixturenet-laconicd build-npms
+
+# Clean up
+$TEST_TARGET_SO --stack package-registry deploy-system down
+echo "Test passed"


### PR DESCRIPTION
passes on GitHub Actions, fails on Gitea Actions with:
`jq: error (at <stdin>:1): Cannot index string with string "dist"`, see https://git.vdb.to/cerc-io/stack-orchestrator/actions/runs/593

see also #198. I'm not sure if `jq` is installed on our git.vdb.to, though I installed it on my own host running the gitea stack and the CI threw the same error.

I considered a `--testing` flag to address changing the interactive/tty booleans, which was done at the suggestion of google for the error the CI threw.
