### PR TITLE
Add missing lcli param and open ports for 2nd geth instance.

### DIFF
--- a/app/data/compose/docker-compose-fixturenet-eth.yml
+++ b/app/data/compose/docker-compose-fixturenet-eth.yml
@@ -62,6 +62,9 @@ services:
       - fixturenet-eth-bootnode-geth
     volumes:
       - fixturenet_eth_geth_2_data:/root/ethdata
+    ports:
+      - "8545"
+      - "8546"
 
   fixturenet-eth-bootnode-lighthouse:
     restart: always

--- a/app/data/compose/docker-compose-fixturenet-plugeth.yml
+++ b/app/data/compose/docker-compose-fixturenet-plugeth.yml
@@ -38,6 +38,7 @@ services:
       - fixturenet-eth-bootnode-geth
     ports:
       - "8545"
+      - "8546"
       - "40000"
       - "6060"
 
@@ -59,6 +60,9 @@ services:
       - fixturenet-eth-bootnode-geth
     volumes:
       - fixturenet_plugeth_geth_2_data:/root/ethdata
+    ports:
+      - "8545"
+      - "8546"
 
   fixturenet-eth-bootnode-lighthouse:
     restart: always

--- a/app/data/container-build/cerc-fixturenet-eth-lighthouse/genesis/cl/reset_genesis_time.sh
+++ b/app/data/container-build/cerc-fixturenet-eth-lighthouse/genesis/cl/reset_genesis_time.sh
@@ -13,6 +13,7 @@ NOW=${1:-`date +%s`}
 
 lcli \
   change-genesis-time \
+  --testnet-dir $TESTNET_DIR \
   $TESTNET_DIR/genesis.ssz \
   $NOW
 


### PR DESCRIPTION
Add a missing parameter to lcli which caused the genesis time not to be reset.  I believe this may have been causing sync issues between the lighthouse instances, provided there was a sufficient gap between building the image and launching the fixturenet.

Also open ports for the 2nd geth instance for easier comparison between instances.

