### PR TITLE
Use go-nitro version `v0.1.1-ts-port-0.1.5` in payments stack

### DIFF
--- a/app/data/stacks/fixturenet-payments/stack.yml
+++ b/app/data/stacks/fixturenet-payments/stack.yml
@@ -9,7 +9,7 @@ repos:
   - git.vdb.to/cerc-io/ipld-eth-server@v1.11.6-statediff-v5
   # nitro repos
   - github.com/cerc-io/ts-nitro@v0.1.13
-  - github.com/cerc-io/go-nitro@ts-interop # TODO: Update after fixes
+  - github.com/cerc-io/go-nitro@v0.1.1-ts-port-0.1.5
   # mobymask watcher repos
   - github.com/cerc-io/watcher-ts@v0.2.63
   - github.com/cerc-io/mobymask-v2-watcher-ts@v0.2.2


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/386