### PR TITLE
build watcher-ts on arm

### DIFF
--- a/app/data/container-build/cerc-watcher-ts/Dockerfile
+++ b/app/data/container-build/cerc-watcher-ts/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.17.1-alpine3.18
+FROM node:18.17.1-alpine3.17
 
 RUN apk --update --no-cache add git python3 alpine-sdk jq
 


### PR DESCRIPTION
edit: only closes #561 

Note: the alpine downgrade was the only thing required to build the images on Linux. The `fixturenet-eth-genesis` build failed on M2 with "command not found". Solution found [here](https://command-not-found.com/envsubst)

The images built, however, the `fixturenet-payments` deployment errored.

Not tested in any other stack or platform