### PR TITLE
Don't error when CERC_GO_AUTH_TOKEN isn't set

### DIFF
--- a/app/data/container-build/cerc-plugeth-statediff/build.sh
+++ b/app/data/container-build/cerc-plugeth-statediff/build.sh
@@ -2,4 +2,7 @@
 # Build cerc/plugeth-statediff
 source ${CERC_CONTAINER_BASE_DIR}/build-base.sh
 # Pass Go auth token if present
-docker build -t cerc/plugeth-statediff:local ${build_command_args} --build-arg GIT_VDBTO_TOKEN=${CERC_GO_AUTH_TOKEN} ${CERC_REPO_BASE_DIR}/plugeth-statediff
+if [[ -n "${CERC_GO_AUTH_TOKEN}" ]]; then
+    build_command_args="${build_command_args} --build-arg GIT_VDBTO_TOKEN=${CERC_GO_AUTH_TOKEN}"
+fi
+docker build -t cerc/plugeth-statediff:local ${build_command_args} ${CERC_REPO_BASE_DIR}/plugeth-statediff

--- a/app/data/container-build/cerc-plugeth-statediff/build.sh
+++ b/app/data/container-build/cerc-plugeth-statediff/build.sh
@@ -1,10 +1,4 @@
 #!/usr/bin/env bash
 # Build cerc/plugeth-statediff
 source ${CERC_CONTAINER_BASE_DIR}/build-base.sh
-# This container build currently requires access to private dependencies in gitea
-# so we check that the necessary access token has been supplied here, then pass it o the build
-if [[ -z "${CERC_GO_AUTH_TOKEN}" ]]; then
-    echo "ERROR: CERC_GO_AUTH_TOKEN is not set" >&2
-    exit 1
-fi
 docker build -t cerc/plugeth-statediff:local ${build_command_args} --build-arg GIT_VDBTO_TOKEN=${CERC_GO_AUTH_TOKEN} ${CERC_REPO_BASE_DIR}/plugeth-statediff

--- a/app/data/container-build/cerc-plugeth-statediff/build.sh
+++ b/app/data/container-build/cerc-plugeth-statediff/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 # Build cerc/plugeth-statediff
 source ${CERC_CONTAINER_BASE_DIR}/build-base.sh
+# Pass Go auth token if present
 docker build -t cerc/plugeth-statediff:local ${build_command_args} --build-arg GIT_VDBTO_TOKEN=${CERC_GO_AUTH_TOKEN} ${CERC_REPO_BASE_DIR}/plugeth-statediff

--- a/app/data/container-build/cerc-plugeth/build.sh
+++ b/app/data/container-build/cerc-plugeth/build.sh
@@ -2,4 +2,7 @@
 # Build cerc/plugeth
 source ${CERC_CONTAINER_BASE_DIR}/build-base.sh
 # Pass Go auth token if present
-docker build -t cerc/plugeth:local ${build_command_args} --build-arg GIT_VDBTO_TOKEN=${CERC_GO_AUTH_TOKEN} ${CERC_REPO_BASE_DIR}/plugeth
+if [[ -n "${CERC_GO_AUTH_TOKEN}" ]]; then
+    build_command_args="${build_command_args} --build-arg GIT_VDBTO_TOKEN=${CERC_GO_AUTH_TOKEN}"
+fi
+docker build -t cerc/plugeth:local ${build_command_args} ${CERC_REPO_BASE_DIR}/plugeth

--- a/app/data/container-build/cerc-plugeth/build.sh
+++ b/app/data/container-build/cerc-plugeth/build.sh
@@ -1,10 +1,4 @@
 #!/usr/bin/env bash
 # Build cerc/plugeth
 source ${CERC_CONTAINER_BASE_DIR}/build-base.sh
-# This container build currently requires access to private dependencies in gitea
-# so we check that the necessary access token has been supplied here, then pass it o the build
-if [[ -z "${CERC_GO_AUTH_TOKEN}" ]]; then
-    echo "ERROR: CERC_GO_AUTH_TOKEN is not set" >&2
-    exit 1
-fi
 docker build -t cerc/plugeth:local ${build_command_args} --build-arg GIT_VDBTO_TOKEN=${CERC_GO_AUTH_TOKEN} ${CERC_REPO_BASE_DIR}/plugeth

--- a/app/data/container-build/cerc-plugeth/build.sh
+++ b/app/data/container-build/cerc-plugeth/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 # Build cerc/plugeth
 source ${CERC_CONTAINER_BASE_DIR}/build-base.sh
+# Pass Go auth token if present
 docker build -t cerc/plugeth:local ${build_command_args} --build-arg GIT_VDBTO_TOKEN=${CERC_GO_AUTH_TOKEN} ${CERC_REPO_BASE_DIR}/plugeth

--- a/app/data/stacks/fixturenet-plugeth-tx/README.md
+++ b/app/data/stacks/fixturenet-plugeth-tx/README.md
@@ -12,7 +12,7 @@ See `stacks/fixturenet-eth/README.md` for more information.
 * cerc/tx-spammer
 
 ## Deploy the stack
-Note: since some Go dependencies are currently private, `CERC_GO_AUTH_TOKEN` must be set to a valid Gitea access token before running the `build-containers` command.
+Note: if there are any private Go dependencies, `CERC_GO_AUTH_TOKEN` must be set to a valid Gitea access token before running the `build-containers` command.
 ```
 $ laconic-so --stack fixturenet-plugeth-tx setup-repositories
 $ laconic-so --stack fixturenet-plugeth-tx build-containers


### PR DESCRIPTION
All dependencies are now public.