### PR TITLE
53: Make sure curl and jq are present in the container.

### DIFF
--- a/app/data/container-build/cerc-fixturenet-eth-lighthouse/scripts/export-ethdb.sh
+++ b/app/data/container-build/cerc-fixturenet-eth-lighthouse/scripts/export-ethdb.sh
@@ -20,21 +20,24 @@ if [[ $? -ne 0 ]]; then
   exit 1
 fi
 
-# Stop geth.
-echo -n "Exporting ethdb.... "
 GETH_CONTAINER=`docker ps -q -f "name=${CERC_SO_COMPOSE_PROJECT}-fixturenet-eth-geth-2-1"`
 if [[ -z "$GETH_CONTAINER" ]]; then
   echo "not found"
   exit 1
 fi
 
+# Make sure we have the necessary tools
+docker exec $GETH_CONTAINER sh -c 'apk add --no-cache jq curl'
+
+# Gather metadata.
 docker exec $GETH_CONTAINER sh -c 'rm -rf /root/tmp && mkdir -p /root/tmp/export'
 docker exec $GETH_CONTAINER sh -c 'ln -s /opt/testnet/build/el/geth.json /root/tmp/export/genesis.json && ln -s /root/ethdata /root/tmp/export/'
 docker exec $GETH_CONTAINER sh -c 'cat /root/tmp/export/genesis.json | jq ".config" > /root/tmp/export/genesis.config.json'
-
-# Stop geth and zip up ethdb.
 docker exec $GETH_CONTAINER sh -c 'curl -s --location "localhost:8545" --header "Content-Type: application/json" --data "{\"jsonrpc\": \"2.0\", \"id\": 1, \"method\": \"eth_getBlockByNumber\", \"params\": [\"0x0\", false]}" > /root/tmp/export/eth_getBlockByNumber_0x0.json'
 docker exec $GETH_CONTAINER sh -c 'curl -s --location "localhost:8545" --header "Content-Type: application/json" --data "{\"jsonrpc\": \"2.0\", \"id\": 1, \"method\": \"eth_blockNumber\", \"params\": []}" > /root/tmp/export/eth_blockNumber.json'
+
+# Stop geth and zip up ethdb.
+echo -n "Exporting ethdb.... "
 docker exec $GETH_CONTAINER sh -c "killall geth && sleep 2 && tar chzf /root/tmp/ethdb.tgz -C /root/tmp/export ."
 
 # Copy ethdb to host.


### PR DESCRIPTION
Fix for https://git.vdb.to/cerc-io/chain-chunker/issues/53.

I think these must have been removed from the base container, since it wasn't obvious why we needed them.  Rather than increasing the size of the container when most people won't need to export anyway, let's just add them when required.