### PR TITLE
Update stacks for migrated laconic repos.

### DIFF
--- a/app/data/stacks/fixturenet-laconic-loaded/stack.yml
+++ b/app/data/stacks/fixturenet-laconic-loaded/stack.yml
@@ -2,14 +2,14 @@ version: "1.1"
 name: fixturenet-laconic-loaded
 description: "A full featured laconic fixturenet"
 repos:
-  - github.com/cerc-io/laconicd
+  - git.vdb.to/cerc-io/laconicd
   - github.com/lirewine/debug
   - github.com/lirewine/crypto
   - github.com/lirewine/gem
   - github.com/lirewine/sdk
-  - github.com/cerc-io/laconic-sdk
-  - github.com/cerc-io/laconic-registry-cli
-  - github.com/cerc-io/laconic-console
+  - git.vdb.to/cerc-io/laconic-sdk
+  - git.vdb.to/cerc-io/laconic-registry-cli
+  - git.vdb.to/cerc-io/laconic-console
 npms:
   - laconic-sdk
   - laconic-registry-cli

--- a/app/data/stacks/fixturenet-laconicd/stack.yml
+++ b/app/data/stacks/fixturenet-laconicd/stack.yml
@@ -2,9 +2,9 @@ version: "1.0"
 name: fixturenet-laconicd
 description: "A laconicd fixturenet"
 repos:
-  - github.com/cerc-io/laconicd
-  - github.com/cerc-io/laconic-sdk
-  - github.com/cerc-io/laconic-registry-cli
+  - git.vdb.to/cerc-io/laconicd
+  - git.vdb.to/cerc-io/laconic-sdk
+  - git.vdb.to/cerc-io/laconic-registry-cli
 npms:
   - laconic-sdk
   - laconic-registry-cli

--- a/app/data/stacks/test/stack.yml
+++ b/app/data/stacks/test/stack.yml
@@ -2,7 +2,7 @@ version: "1.0"
 name: test
 description: "A test stack"
 repos:
-  - github.com/cerc-io/laconicd
+  - git.vdb.to/cerc-io/laconicd
   - git.vdb.to/cerc-io/test-project@test-branch
 containers:
   - cerc/test-container


### PR DESCRIPTION
Update stacks for repos migrated to git.vdb.to:

  - github.com/cerc-io/laconic-console
  - github.com/cerc-io/laconic-registry-cli
  - github.com/cerc-io/laconic-sdk
  - github.com/cerc-io/laconicd