### PR TITLE
Add plugeth to chain-chunker stack (needed for new verify option).

### DIFF
--- a/app/data/stacks/chain-chunker/stack.yml
+++ b/app/data/stacks/chain-chunker/stack.yml
@@ -6,8 +6,10 @@ repos:
   - git.vdb.to/cerc-io/eth-statediff-service@v5
   - git.vdb.to/cerc-io/ipld-eth-db@v5
   - git.vdb.to/cerc-io/ipld-eth-server@v5
+  - git.vdb.to/cerc-io/plugeth@statediff
 containers:
   - cerc/ipld-eth-state-snapshot
   - cerc/eth-statediff-service
   - cerc/ipld-eth-db
   - cerc/ipld-eth-server
+  - cerc/plugeth


### PR DESCRIPTION
The new option to verify using a local LevelDB requires plugeth.