### PR TITLE
Fix KeyError accessing config.

### DIFF
--- a/app/deploy/deployment_create.py
+++ b/app/deploy/deployment_create.py
@@ -261,7 +261,7 @@ def init(ctx, config, output, map_ports_to_host):
     config_variables = _parse_config_variables(config)
     if config_variables:
         # Implement merge, since update() overwrites
-        orig_config = spec_file_content["config"]
+        orig_config = spec_file_content.get("config", {})
         new_config = config_variables["config"]
         merged_config = {**new_config, **orig_config}
         spec_file_content.update({"config": merged_config})


### PR DESCRIPTION
Fixes:

```
laconic-so --stack act-runner deploy init --output act-runner.yml --config CERC_GITEA_RUNNER_REGISTRATION_TOKEN=FOO
Traceback (most recent call last):
  File "/home/telackey/cerc/stack-orchestrator/venv/bin/laconic-so", line 33, in <module>
    sys.exit(load_entry_point('laconic-stack-orchestrator', 'console_scripts', 'laconic-so')())
  File "/home/telackey/cerc/stack-orchestrator/venv/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/telackey/cerc/stack-orchestrator/venv/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/telackey/cerc/stack-orchestrator/venv/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/telackey/cerc/stack-orchestrator/venv/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/telackey/cerc/stack-orchestrator/venv/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/telackey/cerc/stack-orchestrator/venv/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/telackey/cerc/stack-orchestrator/venv/lib/python3.10/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/telackey/cerc/stack-orchestrator/app/deploy/deployment_create.py", line 264, in init
    orig_config = spec_file_content["config"]
KeyError: 'config'
```