### PR TITLE
Support the case where webpack config is already present next.config.js

### DIFF
--- a/stack_orchestrator/build/build_webapp.py
+++ b/stack_orchestrator/build/build_webapp.py
@@ -65,6 +65,7 @@ def command(ctx, base_container, source_repo, force_rebuild, extra_build_args):
 
 
     # Now build the target webapp.  We use the same build script, but with a different Dockerfile and work dir.
+    container_build_env["CERC_WEBAPP_BUILD_RUNNING"] = "true"
     container_build_env["CERC_CONTAINER_BUILD_WORK_DIR"] = os.path.abspath(source_repo)
     container_build_env["CERC_CONTAINER_BUILD_DOCKERFILE"] = os.path.join(container_build_dir,
                                                                     base_container.replace("/", "-"),

--- a/stack_orchestrator/data/container-build/cerc-nextjs-base/Dockerfile
+++ b/stack_orchestrator/data/container-build/cerc-nextjs-base/Dockerfile
@@ -1,6 +1,6 @@
 # Originally from: https://github.com/devcontainers/images/blob/main/src/javascript-node/.devcontainer/Dockerfile
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
-ARG VARIANT=18-bullseye
+ARG VARIANT=20-bullseye
 FROM node:${VARIANT}
 
 ARG USERNAME=node

--- a/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/apply-runtime-env.sh
+++ b/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/apply-runtime-env.sh
@@ -25,12 +25,12 @@ if [ -f ".env" ]; then
 fi
 
 for f in $(find "$TRG_DIR" -regex ".*.[tj]sx?$" -type f | grep -v 'node_modules'); do
-  for e in $(cat "${f}" | tr -s '[:blank:]' '\n' | tr -s '[{},()]' '\n' | egrep -o '^"CERC_RUNTIME_ENV[^\"]+"$'); do
+  for e in $(cat "${f}" | tr -s '[:blank:]' '\n' | tr -s '[{},();]' '\n' | egrep -o '^"CERC_RUNTIME_ENV_[^\"]+"'); do
     orig_name=$(echo -n "${e}" | sed 's/"//g')
     cur_name=$(echo -n "${orig_name}" | sed 's/CERC_RUNTIME_ENV_//g')
     cur_val=$(echo -n "\$${cur_name}" | envsubst)
     esc_val=$(sed 's/[&/\]/\\&/g' <<< "$cur_val")
-    echo "$cur_name=$cur_val"
+    echo "$f: $cur_name=$cur_val"
     sed -i "s/$orig_name/$esc_val/g" $f
   done
 done

--- a/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/build-app.sh
+++ b/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/build-app.sh
@@ -10,21 +10,25 @@ WORK_DIR="${1:-/app}"
 
 cd "${WORK_DIR}" || exit 1
 
-cp next.config.js next.config.dist
+if [ ! -f "next.config.dist" ]; then
+  cp next.config.js next.config.dist
+fi
 
-npm i -g js-beautify
+which js-beautify >/dev/null
+if [ $? -ne 0 ]; then
+  npm i -g js-beautify
+fi
+
 js-beautify next.config.dist > next.config.js
 
-npm install
+WEBPACK_REQ_LINE=$(grep -n "require([\'\"]webpack[\'\"])" next.config.js | cut -d':' -f1)
+if [ -z "$WEBPACK_REQ_LINE" ]; then
+  cat > next.config.js.0 <<EOF
+    const webpack = require('webpack');
+EOF
+fi
 
-CONFIG_LINES=$(wc -l next.config.js | awk '{ print $1 }')
-MOD_EXPORTS_LINE=$(grep -n 'module.exports' next.config.js | cut -d':' -f1)
-
-head -$(( ${MOD_EXPORTS_LINE} - 1 )) next.config.js > next.config.js.1
-
-cat > next.config.js.2 <<EOF
-const webpack = require('webpack');
-
+cat > next.config.js.1 <<EOF
 let envMap;
 try {
   // .env-list.json provides us a list of identifiers which should be replaced at runtime.
@@ -43,21 +47,42 @@ try {
 }
 EOF
 
-grep 'module.exports' next.config.js > next.config.js.3
+CONFIG_LINES=$(wc -l next.config.js | awk '{ print $1 }')
+ENV_LINE=$(grep -n 'env:' next.config.js | cut -d':' -f1)
+WEBPACK_CONF_LINE=$(egrep -n 'webpack:\s+\([^,]+,' next.config.js | cut -d':' -f1)
+NEXT_SECTION_ADJUSTMENT=0
 
-cat > next.config.js.4 <<EOF
-  webpack: (config) => {
-    config.plugins.push(new webpack.DefinePlugin(envMap));
-    return config;
-  },
+if [ -n "$WEBPACK_CONF_LINE" ]; then
+  WEBPACK_CONF_VAR=$(egrep -n 'webpack:\s+\([^,]+,' next.config.js | cut -d',' -f1 | cut -d'(' -f2)
+  head -$(( ${WEBPACK_CONF_LINE} )) next.config.js > next.config.js.2
+  cat > next.config.js.3 <<EOF
+      $WEBPACK_CONF_VAR.plugins.push(new webpack.DefinePlugin(envMap));
 EOF
+  NEXT_SECTION_LINE=$((WEBPACK_CONF_LINE - 1))
+elif [ -n "$ENV_LINE" ]; then
+  head -$(( ${ENV_LINE} - 1 )) next.config.js > next.config.js.2
+  cat > next.config.js.3 <<EOF
+    webpack: (config) => {
+      config.plugins.push(new webpack.DefinePlugin(envMap));
+      return config;
+    },
+EOF
+  NEXT_SECTION_ADJUSTMENT=2
+  NEXT_SECTION_LINE=$ENV_LINE
+else
+  echo "WARNING: Cannot find location to insert environment variable map in next.config.js" 1>&2
+  rm -f next.config.js.*
+  NEXT_SECTION_LINE=0
+fi
 
-tail -$(( ${CONFIG_LINES} - ${MOD_EXPORTS_LINE} + 1 )) next.config.js | grep -v 'process\.env\.' > next.config.js.5
+tail -$(( ${CONFIG_LINES} - ${NEXT_SECTION_LINE} + ${NEXT_SECTION_ADJUSTMENT} )) next.config.js > next.config.js.5
 
-cat next.config.js.* | js-beautify > next.config.js
+cat next.config.js.* | sed 's/^ *//g' | js-beautify | grep -v 'process\.\env\.' | js-beautify | tee next.config.js
 rm next.config.js.*
 
 "${SCRIPT_DIR}/find-env.sh" "$(pwd)" > .env-list.json
 
-npm run build
-rm .env-list.json
+npm install || exit 1
+npm run build || exit 1
+
+exit 0

--- a/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/build-app.sh
+++ b/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/build-app.sh
@@ -77,12 +77,18 @@ fi
 
 tail -$(( ${CONFIG_LINES} - ${NEXT_SECTION_LINE} + ${NEXT_SECTION_ADJUSTMENT} )) next.config.js > next.config.js.5
 
-cat next.config.js.* | sed 's/^ *//g' | js-beautify | grep -v 'process\.\env\.' | js-beautify | tee next.config.js
+cat next.config.js.* | sed 's/^ *//g' | js-beautify | grep -v 'process\.\env\.' | js-beautify > next.config.js
 rm next.config.js.*
 
 "${SCRIPT_DIR}/find-env.sh" "$(pwd)" > .env-list.json
 
+if [ ! -f "package.dist" ]; then
+  cp package.json package.dist
+fi
+
+cat package.dist | jq '.scripts.cerc_compile = "next experimental-compile"' | jq '.scripts.cerc_generate = "next experimental-generate"' > package.json
+
 npm install || exit 1
-npm run build || exit 1
+npm run cerc_compile || exit 1
 
 exit 0

--- a/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/find-env.sh
+++ b/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/find-env.sh
@@ -20,5 +20,10 @@ for d in $(find . -maxdepth 1 -type d | grep -v '\./\.' | grep '/' | cut -d'/' -
   done
 done
 
+NEXT_CONF="next.config.js next.config.dist"
+for f in $NEXT_CONF; do
+    cat "$f" | tr -s '[:blank:]' '\n' | tr -s '[{},()]' '\n' | egrep -o 'process.env.[A-Za-z0-9_]+' >> $TMPF
+done
+
 cat $TMPF | sort -u | jq  --raw-input .  | jq --slurp .
 rm -f $TMPF

--- a/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/start-serving-app.sh
+++ b/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/start-serving-app.sh
@@ -8,6 +8,27 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 CERC_WEBAPP_FILES_DIR="${CERC_WEBAPP_FILES_DIR:-/app}"
 cd "$CERC_WEBAPP_FILES_DIR"
 
-rm -rf .next-r
 "$SCRIPT_DIR/apply-runtime-env.sh" "`pwd`" .next .next-r
-npm start .next-r -p ${CERC_LISTEN_PORT:-3000}
+mv .next .next.old
+mv .next-r/.next .
+
+if [ "$CERC_NEXTJS_SKIP_GENERATE" != "true" ]; then
+  jq -e '.scripts.cerc_generate' package.json >/dev/null
+  if [ $? -eq 0 ]; then
+    npm run cerc_generate > gen.out 2>&1 &
+    tail -n0 -f gen.out | sed '/rendered as static HTML/ q'
+    count=0
+    while [ $count -lt 10 ]; do
+      sleep 1
+      ps -ef | grep 'node' | grep 'next' | grep 'generate' >/dev/null
+      if [ $? -ne 0 ]; then 
+        break
+      else
+        count=$((count + 1))
+      fi
+    done
+    kill $(ps -ef |grep node | grep next | grep generate | awk '{print $2}') 2>/dev/null
+  fi
+fi
+
+npm start . -p ${CERC_LISTEN_PORT:-3000}


### PR DESCRIPTION
This fixes a bug where the build-app.sh script failed to re-write next.config.js properly if the 'webpack' property were already present in the config.

It also adds support for NextJS's experimental compile/generate build workflow.