### PR TITLE
Upgrade release versions for merkl and sushiswap watchers

### DIFF
--- a/stack_orchestrator/data/compose/docker-compose-watcher-merkl-sushiswap-v3.yml
+++ b/stack_orchestrator/data/compose/docker-compose-watcher-merkl-sushiswap-v3.yml
@@ -13,7 +13,7 @@ services:
       - ../config/postgresql/multiple-postgressql-databases.sh:/docker-entrypoint-initdb.d/multiple-postgressql-databases.sh
       - merkl_sushiswap_v3_watcher_db_data:/var/lib/postgresql/data
     ports:
-      - "127.0.0.1:15432:5432"
+      - "5432"
     healthcheck:
       test: ["CMD", "nc", "-v", "localhost", "5432"]
       interval: 20s
@@ -35,7 +35,7 @@ services:
       - ../config/watcher-merkl-sushiswap-v3/watcher-config-template.toml:/app/environments/watcher-config-template.toml
       - ../config/watcher-merkl-sushiswap-v3/start-job-runner.sh:/app/start-job-runner.sh
     ports:
-      - "127.0.0.1:9000:9000"
+      - "9000"
     healthcheck:
       test: ["CMD", "nc", "-v", "localhost", "9000"]
       interval: 20s
@@ -63,7 +63,7 @@ services:
       - ../config/watcher-merkl-sushiswap-v3/start-server.sh:/app/start-server.sh
     ports:
       - "127.0.0.1:3007:3008"
-      - "127.0.0.1:9001:9001"
+      - "9001"
     healthcheck:
       test: ["CMD", "nc", "-v", "localhost", "3008"]
       interval: 20s

--- a/stack_orchestrator/data/compose/docker-compose-watcher-sushiswap-v3.yml
+++ b/stack_orchestrator/data/compose/docker-compose-watcher-sushiswap-v3.yml
@@ -13,7 +13,7 @@ services:
       - ../config/postgresql/multiple-postgressql-databases.sh:/docker-entrypoint-initdb.d/multiple-postgressql-databases.sh
       - sushiswap_v3_watcher_db_data:/var/lib/postgresql/data
     ports:
-      - "127.0.0.1:15432:5432"
+      - "5432"
     healthcheck:
       test: ["CMD", "nc", "-v", "localhost", "5432"]
       interval: 20s
@@ -35,7 +35,7 @@ services:
       - ../config/watcher-sushiswap-v3/watcher-config-template.toml:/app/environments/watcher-config-template.toml
       - ../config/watcher-sushiswap-v3/start-job-runner.sh:/app/start-job-runner.sh
     ports:
-      - "127.0.0.1:9000:9000"
+      - "9000"
     healthcheck:
       test: ["CMD", "nc", "-v", "localhost", "9000"]
       interval: 20s
@@ -63,7 +63,7 @@ services:
       - ../config/watcher-sushiswap-v3/start-server.sh:/app/start-server.sh
     ports:
       - "127.0.0.1:3008:3008"
-      - "127.0.0.1:9001:9001"
+      - "9001"
     healthcheck:
       test: ["CMD", "nc", "-v", "localhost", "3008"]
       interval: 20s

--- a/stack_orchestrator/data/config/watcher-merkl-sushiswap-v3/watcher-config-template.toml
+++ b/stack_orchestrator/data/config/watcher-merkl-sushiswap-v3/watcher-config-template.toml
@@ -81,7 +81,8 @@
   jobDelayInMilliSecs = 100
   eventsInBatch = 50
   subgraphEventsOrder = true
-  blockDelayInMilliSecs = 2000
+  # Filecoin block time: https://docs.filecoin.io/basics/the-blockchain/blocks-and-tipsets#blocktime
+  blockDelayInMilliSecs = 30000
   prefetchBlocksInMem = false
   prefetchBlockCount = 10
 

--- a/stack_orchestrator/data/config/watcher-sushiswap-v3/watcher-config-template.toml
+++ b/stack_orchestrator/data/config/watcher-sushiswap-v3/watcher-config-template.toml
@@ -81,7 +81,8 @@
   jobDelayInMilliSecs = 100
   eventsInBatch = 50
   subgraphEventsOrder = true
-  blockDelayInMilliSecs = 2000
+  # Filecoin block time: https://docs.filecoin.io/basics/the-blockchain/blocks-and-tipsets#blocktime
+  blockDelayInMilliSecs = 30000
   prefetchBlocksInMem = false
   prefetchBlockCount = 10
 

--- a/stack_orchestrator/data/container-image-list.txt
+++ b/stack_orchestrator/data/container-image-list.txt
@@ -58,3 +58,4 @@ cerc/mobymask-snap
 cerc/ponder
 cerc/nitro-rpc-client
 cerc/watcher-merkl-sushiswap-v3
+cerc/watcher-sushiswap-v3

--- a/stack_orchestrator/data/pod-list.txt
+++ b/stack_orchestrator/data/pod-list.txt
@@ -44,3 +44,4 @@ mobymask-snap
 ponder
 ipld-eth-server-payments
 merkl-sushiswap-v3
+sushiswap-v3

--- a/stack_orchestrator/data/repository-list.txt
+++ b/stack_orchestrator/data/repository-list.txt
@@ -48,3 +48,4 @@ github.com/cerc-io/ts-nitro
 github.com/cerc-io/mobymask-snap
 github.com/cerc-io/ponder
 github.com/cerc-io/merkl-sushiswap-v3-watcher-ts
+github.com/cerc-io/sushiswap-v3-watcher-ts

--- a/stack_orchestrator/data/stacks/merkl-sushiswap-v3/stack.yml
+++ b/stack_orchestrator/data/stacks/merkl-sushiswap-v3/stack.yml
@@ -2,7 +2,7 @@ version: "1.0"
 name: merkl-sushiswap-v3
 description: "SushiSwap v3 watcher stack"
 repos:
-  - github.com/cerc-io/merkl-sushiswap-v3-watcher-ts@v0.1.0
+  - github.com/cerc-io/merkl-sushiswap-v3-watcher-ts@v0.1.1
 containers:
   - cerc/watcher-merkl-sushiswap-v3
 pods:

--- a/stack_orchestrator/data/stacks/sushiswap-v3/stack.yml
+++ b/stack_orchestrator/data/stacks/sushiswap-v3/stack.yml
@@ -2,7 +2,7 @@ version: "1.0"
 name: sushiswap-v3
 description: "SushiSwap v3 watcher stack"
 repos:
-  - github.com/cerc-io/sushiswap-v3-watcher-ts@v0.1.0
+  - github.com/cerc-io/sushiswap-v3-watcher-ts@v0.1.1
 containers:
   - cerc/watcher-sushiswap-v3
 pods:


### PR DESCRIPTION
Part of [Create SO stacks for sushiswap and merkl-sushiswap subgraph watchers](https://www.notion.so/Create-SO-stacks-for-sushiswap-and-merkl-sushiswap-subgraph-watchers-a7f8efe2a5ec434089fd841f5a750236)

- Avoid mapping ports in docker compose that are not exposed
- Upgrade watcher release versions
- Increase blockDelayInMillSecs in watcher config