### PR TITLE
646: Add error message for webapp startup hang

### DIFF
--- a/stack_orchestrator/data/container-build/cerc-nextjs-base/Dockerfile
+++ b/stack_orchestrator/data/container-build/cerc-nextjs-base/Dockerfile
@@ -39,4 +39,4 @@ EXPOSE 3000
 COPY /scripts /scripts
 
 # Default command sleeps forever so docker doesn't kill it
-CMD ["/scripts/start-serving-app.sh"]
+ENTRYPOINT ["/scripts/start-serving-app.sh"]

--- a/stack_orchestrator/data/container-build/cerc-nextjs-base/build.sh
+++ b/stack_orchestrator/data/container-build/cerc-nextjs-base/build.sh
@@ -23,7 +23,7 @@ Built host container for $CERC_CONTAINER_BUILD_WORK_DIR with tag:
 
 To test locally run:
 
-    docker run -p 3000:3000 $CERC_CONTAINER_BUILD_TAG
+    docker run -p 3000:3000 --env-file /path/to/environment.env $CERC_CONTAINER_BUILD_TAG
 
 EOF
 fi

--- a/stack_orchestrator/data/container-build/cerc-nextjs-base/build.sh
+++ b/stack_orchestrator/data/container-build/cerc-nextjs-base/build.sh
@@ -11,3 +11,19 @@ CERC_CONTAINER_BUILD_DOCKERFILE=${CERC_CONTAINER_BUILD_DOCKERFILE:-$SCRIPT_DIR/D
 CERC_CONTAINER_BUILD_TAG=${CERC_CONTAINER_BUILD_TAG:-cerc/nextjs-base:local}
 
 docker build -t $CERC_CONTAINER_BUILD_TAG ${build_command_args} -f $CERC_CONTAINER_BUILD_DOCKERFILE $CERC_CONTAINER_BUILD_WORK_DIR
+
+if [ $? -eq 0 ] && [ "$CERC_CONTAINER_BUILD_TAG" != "cerc/nextjs-base:local" ]; then
+  cat <<EOF
+
+#################################################################
+
+Built host container for $CERC_CONTAINER_BUILD_WORK_DIR with tag:
+
+    $CERC_CONTAINER_BUILD_TAG
+
+To test locally run:
+
+    docker run -p 3000:3000 $CERC_CONTAINER_BUILD_TAG
+
+EOF
+fi

--- a/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/apply-runtime-env.sh
+++ b/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/apply-runtime-env.sh
@@ -38,6 +38,9 @@ for f in $(find "$TRG_DIR" -regex ".*.[tj]sx?$" -type f | grep -v 'node_modules'
     orig_name=$(echo -n "${e}" | sed 's/"//g')
     cur_name=$(echo -n "${orig_name}" | sed 's/CERC_RUNTIME_ENV_//g')
     cur_val=$(echo -n "\$${cur_name}" | envsubst)
+    if [ "$CERC_RETAIN_QUOTES" != "true" ]; then
+      cur_val=$(sed "s/^[\"']//" <<< "$cur_val" | sed "s/[\"']//")
+    fi
     esc_val=$(sed 's/[&/\]/\\&/g' <<< "$cur_val")
     echo "$f: $cur_name=$cur_val"
     sed -i "s/$orig_name/$esc_val/g" $f

--- a/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/apply-runtime-env.sh
+++ b/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/apply-runtime-env.sh
@@ -38,7 +38,7 @@ for f in $(find "$TRG_DIR" -regex ".*.[tj]sx?$" -type f | grep -v 'node_modules'
     orig_name=$(echo -n "${e}" | sed 's/"//g')
     cur_name=$(echo -n "${orig_name}" | sed 's/CERC_RUNTIME_ENV_//g')
     cur_val=$(echo -n "\$${cur_name}" | envsubst)
-    if [ "$CERC_RETAIN_QUOTES" != "true" ]; then
+    if [ "$CERC_RETAIN_ENV_QUOTES" != "true" ]; then
       cur_val=$(sed "s/^[\"']//" <<< "$cur_val" | sed "s/[\"']//")
     fi
     esc_val=$(sed 's/[&/\]/\\&/g' <<< "$cur_val")

--- a/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/start-serving-app.sh
+++ b/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/start-serving-app.sh
@@ -6,6 +6,13 @@ fi
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 CERC_MAX_GENERATE_TIME=${CERC_MAX_GENERATE_TIME:-60}
+tpid=""
+
+ctrl_c() {
+    kill $tpid $(ps -ef | grep node | grep next | awk '{print $2}') 2>/dev/null
+}
+
+trap ctrl_c INT
 
 CERC_BUILD_TOOL="${CERC_BUILD_TOOL}"
 if [ -z "$CERC_BUILD_TOOL" ]; then
@@ -27,23 +34,32 @@ if [ "$CERC_NEXTJS_SKIP_GENERATE" != "true" ]; then
   jq -e '.scripts.cerc_generate' package.json >/dev/null
   if [ $? -eq 0 ]; then
     npm run cerc_generate > gen.out 2>&1 &
-    timeout $CERC_MAX_GENERATE_TIME bash -c "tail -n0 -f gen.out | sed '/rendered as static HTML/ q'"
-    if [ $? -ne 0 ]; then
-      echo "ERROR: 'npm run cerc_generate' exceeded CERC_MAX_GENERATE_TIME."
-      exit 1
-    fi
+    tail -f gen.out &
+    tpid=$!
 
     count=0
-    while [ $count -lt 10 ]; do
+    generate_done="false"
+    while [ $count -lt $CERC_MAX_GENERATE_TIME ]; do
       sleep 1
-      ps -ef | grep 'node' | grep 'next' | grep 'generate' >/dev/null
-      if [ $? -ne 0 ]; then 
-        break
+      grep 'rendered as static HTML' gen.out > /dev/null
+      if [ $? -eq 0 ]; then
+        generate_done="true"
+        ps -ef | grep 'node' | grep 'next' | grep 'generate' >/dev/null
+        if [ $? -ne 0 ]; then
+          break
+        fi
       else
         count=$((count + 1))
       fi
     done
-    kill $(ps -ef |grep node | grep next | grep generate | awk '{print $2}') 2>/dev/null
+
+    if [ $generate_done != "true" ]; then
+      echo "ERROR: 'npm run cerc_generate' not successful within CERC_MAX_GENERATE_TIME" 1>&2
+      exit 1
+    fi
+
+    kill $tpid $(ps -ef | grep node | grep next | grep generate | awk '{print $2}') 2>/dev/null
+    tpid=""
   fi
 fi
 


### PR DESCRIPTION
This fixes three issues:

1. #644 (build output)
2. #646 (error on startup)
3. automatic env quote handling (related to 2)


For the build output we now have:

```
#################################################################

Built host container for /home/telackey/tmp/iglootools-home with tag:

    cerc/iglootools-home:local

To test locally run:

    docker run -p 3000:3000 cerc/iglootools-home:local
```

For the startup error, it was hung waiting for the "success" message from the next generate output (itself a workaround for a nextjs bug fixed by this PR we submitted: https://github.com/vercel/next.js/pull/58276).

I added a timeout which will cause it to wait up to a maximum _n_ seconds before issuing:

```
ERROR: 'npm run cerc_generate' exceeded CERC_MAX_GENERATE_TIME.
```

On the quoting itself, I plan on adding a new run-webapp command, but I realized I had a decent spot to do effect the quote replacement on-the-fly after all when I am already escaping the values for insertion/replacement into JS.

The "dequoting" can be disabled with `CERC_RETAIN_ENV_QUOTES=true`.