### PR TITLE
Fix missing tty parameter.

### DIFF
--- a/stack_orchestrator/deploy/deploy.py
+++ b/stack_orchestrator/deploy/deploy.py
@@ -155,7 +155,7 @@ def exec_operation(ctx, extra_args):
         if global_context.verbose:
             print(f"Running compose exec {service_name} {command_to_exec}")
         try:
-            ctx.obj.deployer.execute(service_name, command_to_exec, envs=container_exec_env)
+            ctx.obj.deployer.execute(service_name, command_to_exec, envs=container_exec_env, tty=True)
         except DeployerException:
             print("container command returned error exit status")
 


### PR DESCRIPTION
Fix for:

```
  File "/home/telackey/cerc/stack-orchestrator/stack_orchestrator/deploy/deploy.py", line 209, in exec
    exec_operation(ctx, extra_args)
  File "/home/telackey/cerc/stack-orchestrator/stack_orchestrator/deploy/deploy.py", line 158, in exec_operation
    ctx.obj.deployer.execute(service_name, command_to_exec, envs=container_exec_env)
TypeError: DockerDeployer.execute() missing 1 required positional argument: 'tty'
```