### PR TITLE
Upgrade azimuth watcher release version to `0.1.2`

### DIFF
--- a/stack_orchestrator/data/config/watcher-azimuth/watcher-config-template.toml
+++ b/stack_orchestrator/data/config/watcher-azimuth/watcher-config-template.toml
@@ -18,3 +18,4 @@
 
 [jobQueue]
   historicalLogsBlockRange = REPLACE_WITH_CERC_HISTORICAL_BLOCK_RANGE
+  blockDelayInMilliSecs = 12000

--- a/stack_orchestrator/data/stacks/azimuth/stack.yml
+++ b/stack_orchestrator/data/stacks/azimuth/stack.yml
@@ -1,7 +1,7 @@
 version: "1.0"
 name: azimuth
 repos:
-  - github.com/cerc-io/azimuth-watcher-ts
+  - github.com/cerc-io/azimuth-watcher-ts@0.1.2
 containers:
   - cerc/watcher-azimuth
 pods:


### PR DESCRIPTION
Part of [Update azimuth watcher stack to run in active mode](https://www.notion.so/Update-azimuth-watcher-stack-to-run-in-active-mode-4b4f86ab3ab54943b216af37ac4fb50d?pvs=23)

- Update `blockDelayInMilliSecs` to 12 seconds (avg. time taken for new block in ethereum)
- Upgrade azimuth watcher release version to 0.1.2