### PR TITLE
Add --port option to run-webapp.

### DIFF
--- a/stack_orchestrator/deploy/compose/deploy_docker.py
+++ b/stack_orchestrator/deploy/compose/deploy_docker.py
@@ -64,10 +64,10 @@ class DockerDeployer(Deployer):
         except DockerException as e:
             raise DeployerException(e)
 
-    def run(self, image: str, command=None, user=None, volumes=None, entrypoint=None, env={}, detach=False):
+    def run(self, image: str, command=None, user=None, volumes=None, entrypoint=None, env={}, ports=[], detach=False):
         try:
             return self.docker.run(image=image, command=command, user=user, volumes=volumes,
-                                   entrypoint=entrypoint, envs=env, detach=detach, publish_all=True)
+                                   entrypoint=entrypoint, envs=env, detach=detach, publish=ports, publish_all=len(ports) == 0)
         except DockerException as e:
             raise DeployerException(e)
 

--- a/stack_orchestrator/deploy/deployer.py
+++ b/stack_orchestrator/deploy/deployer.py
@@ -44,7 +44,7 @@ class Deployer(ABC):
         pass
 
     @abstractmethod
-    def run(self, image: str, command=None, user=None, volumes=None, entrypoint=None, env={}, detach=False):
+    def run(self, image: str, command=None, user=None, volumes=None, entrypoint=None, env={}, ports=[], detach=False):
         pass
 
 

--- a/stack_orchestrator/deploy/k8s/deploy_k8s.py
+++ b/stack_orchestrator/deploy/k8s/deploy_k8s.py
@@ -230,7 +230,7 @@ class K8sDeployer(Deployer):
         log_data = self.core_api.read_namespaced_pod_log(k8s_pod_name, namespace="default", container="test")
         return log_stream_from_string(log_data)
 
-    def run(self, image: str, command=None, user=None, volumes=None, entrypoint=None, env={}, detach=False):
+    def run(self, image: str, command=None, user=None, volumes=None, entrypoint=None, env={}, ports=[], detach=False):
         # We need to figure out how to do this -- check why we're being called first
         pass
 

--- a/stack_orchestrator/deploy/webapp/run_webapp.py
+++ b/stack_orchestrator/deploy/webapp/run_webapp.py
@@ -34,7 +34,7 @@ WEBAPP_PORT = 3000
 @click.option("--env-file", help="environment file for webapp")
 @click.option("--port", help="port to use (default random)")
 @click.pass_context
-def command(ctx, image, deploy_to, env_file, port):
+def command(ctx, image, env_file, port):
     '''run the specified webapp container'''
 
     env = {}

--- a/stack_orchestrator/deploy/webapp/run_webapp.py
+++ b/stack_orchestrator/deploy/webapp/run_webapp.py
@@ -27,13 +27,15 @@ from dotenv import dotenv_values
 from stack_orchestrator import constants
 from stack_orchestrator.deploy.deployer_factory import getDeployer
 
+WEBAPP_PORT = 3000
 
 @click.command()
 @click.option("--image", help="image to deploy", required=True)
 @click.option("--env-file", help="environment file for webapp")
+@click.option("--port", help="port to use (default random)")
 @click.pass_context
-def command(ctx, image, env_file):
-    '''build the specified webapp container'''
+def command(ctx, image, deploy_to, env_file, port):
+    '''run the specified webapp container'''
 
     env = {}
     if env_file:
@@ -49,10 +51,13 @@ def command(ctx, image, env_file):
                            compose_project_name=cluster,
                            compose_env_file=None)
 
-    container = deployer.run(image, command=[], user=None, volumes=[], entrypoint=None, env=env, detach=True)
+    ports = []
+    if port:
+        ports = [(port, WEBAPP_PORT)]
+    container = deployer.run(image, command=[], user=None, volumes=[], entrypoint=None, env=env, ports=ports, detach=True)
 
     # Make configurable?
-    webappPort = "3000/tcp"
+    webappPort = f"{WEBAPP_PORT}/tcp"
     # TODO: This assumes a Docker container object...
     if webappPort in container.network_settings.ports:
         mapping = container.network_settings.ports[webappPort][0]

--- a/stack_orchestrator/deploy/webapp/run_webapp.py
+++ b/stack_orchestrator/deploy/webapp/run_webapp.py
@@ -29,6 +29,7 @@ from stack_orchestrator.deploy.deployer_factory import getDeployer
 
 WEBAPP_PORT = 3000
 
+
 @click.command()
 @click.option("--image", help="image to deploy", required=True)
 @click.option("--env-file", help="environment file for webapp")


### PR DESCRIPTION
Short of a full deployment, being able to specify the port can still be useful (eg, in scripting).

```
❯ laconic-so run-webapp --image cerc/test-progressive-web-app:local --port 4243
Image: cerc/test-progressive-web-app:local
ID: c6642396ebc339f2f4f6fca4ff353e67214002370228a5b4aad08b47cdd6b4e7
URL: http://localhost:4243
```