### PR TITLE
If the next version is unsupported, print a big warning and try higher version.

### DIFF
--- a/stack_orchestrator/data/container-build/cerc-nextjs-base/Dockerfile
+++ b/stack_orchestrator/data/container-build/cerc-nextjs-base/Dockerfile
@@ -24,6 +24,8 @@ RUN \
     && su ${USERNAME} -c "npm config -g set prefix ${NPM_GLOBAL}" \
     # Install eslint
     && su ${USERNAME} -c "umask 0002 && npm install -g eslint" \
+    # Install semver
+    && su ${USERNAME} -c "umask 0002 && npm install -g semver" \
     && npm cache clean --force > /dev/null 2>&1
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/build-app.sh
+++ b/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/build-app.sh
@@ -120,10 +120,10 @@ if [ $? -ne 0 ]; then
 WARNING: 'next' $CUR_NEXT_VERSION < minimum version $CERC_MIN_NEXTVER.
 
 Attempting to build with '^$CERC_MIN_NEXTVER'.  If this fails, you should upgrade
-the dependency in your webapp, or specify an explicit next version to use for
-the build with:
+the dependency in your webapp, or specify an explicit 'next' version
+to use for the build with:
 
-     --extra-build-args \"--build-arg CERC_NEXT_VERSION=<version>\"
+     --extra-build-args "--build-arg CERC_NEXT_VERSION=<version>"
 
 ###############################################################################
 


### PR DESCRIPTION
```
###############################################################################

WARNING: 'next' 12.3.4 < minimum version 13.4.2.

Attempting to build with '^13.4.2'.  If this fails, you should upgrade
the dependency in your webapp, or specify an explicit next version
to use for the build with:

     --extra-build-args "--build-arg CERC_NEXT_VERSION=<version>"

###############################################################################
```