### PR TITLE
Change path portion of unique cluster name to point to compose file, not argv[0].

### DIFF
--- a/stack_orchestrator/deploy/deploy.py
+++ b/stack_orchestrator/deploy/deploy.py
@@ -271,8 +271,7 @@ def _make_cluster_context(ctx, stack, include, exclude, cluster, env_file):
 
     if cluster is None:
         # Create default unique, stable cluster name from confile file path and stack name if provided
-        # TODO: change this to the config file path
-        path = os.path.realpath(sys.argv[0])
+        path = os.path.realpath(os.path.abspath(compose_dir))
         unique_cluster_descriptor = f"{path},{stack},{include},{exclude}"
         if ctx.debug:
             print(f"pre-hash descriptor: {unique_cluster_descriptor}")

--- a/stack_orchestrator/deploy/deploy.py
+++ b/stack_orchestrator/deploy/deploy.py
@@ -271,7 +271,10 @@ def _make_cluster_context(ctx, stack, include, exclude, cluster, env_file):
 
     if cluster is None:
         # Create default unique, stable cluster name from confile file path and stack name if provided
-        path = os.path.realpath(os.path.abspath(compose_dir))
+        if deployment:
+            path = os.path.realpath(os.path.abspath(compose_dir))
+        else:
+            path = "internal"
         unique_cluster_descriptor = f"{path},{stack},{include},{exclude}"
         if ctx.debug:
             print(f"pre-hash descriptor: {unique_cluster_descriptor}")


### PR DESCRIPTION
Using argv[0] has the problem of the value changing unexpectedly by whatever name and path were used to execute it (eg, `../foo` vs `/path/to/foo`).

This changes it to put to the full-qualified path to the compose file directory in the case of a deployment, or "internal" in the case of the deploy command with a built-in stack.