### PR TITLE
Expose metrics endpoints for sushiswap and merkl sushiswap watchers

### DIFF
--- a/stack_orchestrator/data/compose/docker-compose-watcher-merkl-sushiswap-v3.yml
+++ b/stack_orchestrator/data/compose/docker-compose-watcher-merkl-sushiswap-v3.yml
@@ -35,7 +35,7 @@ services:
       - ../config/watcher-merkl-sushiswap-v3/watcher-config-template.toml:/app/environments/watcher-config-template.toml
       - ../config/watcher-merkl-sushiswap-v3/start-job-runner.sh:/app/start-job-runner.sh
     ports:
-      - "9000"
+      - "9002:9000"
     healthcheck:
       test: ["CMD", "nc", "-v", "localhost", "9000"]
       interval: 20s
@@ -62,7 +62,7 @@ services:
       - ../config/watcher-merkl-sushiswap-v3/start-server.sh:/app/start-server.sh
     ports:
       - "127.0.0.1:3007:3008"
-      - "9001"
+      - "9003:9001"
     healthcheck:
       test: ["CMD", "nc", "-v", "localhost", "3008"]
       interval: 20s

--- a/stack_orchestrator/data/compose/docker-compose-watcher-sushiswap-v3.yml
+++ b/stack_orchestrator/data/compose/docker-compose-watcher-sushiswap-v3.yml
@@ -35,7 +35,7 @@ services:
       - ../config/watcher-sushiswap-v3/watcher-config-template.toml:/app/environments/watcher-config-template.toml
       - ../config/watcher-sushiswap-v3/start-job-runner.sh:/app/start-job-runner.sh
     ports:
-      - "9000"
+      - "9000:9000"
     healthcheck:
       test: ["CMD", "nc", "-v", "localhost", "9000"]
       interval: 20s
@@ -62,7 +62,7 @@ services:
       - ../config/watcher-sushiswap-v3/start-server.sh:/app/start-server.sh
     ports:
       - "127.0.0.1:3008:3008"
-      - "9001"
+      - "9001:9001"
     healthcheck:
       test: ["CMD", "nc", "-v", "localhost", "3008"]
       interval: 20s

--- a/stack_orchestrator/data/config/watcher-merkl-sushiswap-v3/watcher-config-template.toml
+++ b/stack_orchestrator/data/config/watcher-merkl-sushiswap-v3/watcher-config-template.toml
@@ -41,7 +41,7 @@
     timeTravelMaxAge = 86400 # 1 day
 
 [metrics]
-  host = "127.0.0.1"
+  host = "0.0.0.0"
   port = 9000
   [metrics.gql]
     port = 9001

--- a/stack_orchestrator/data/config/watcher-sushiswap-v3/watcher-config-template.toml
+++ b/stack_orchestrator/data/config/watcher-sushiswap-v3/watcher-config-template.toml
@@ -41,7 +41,7 @@
     timeTravelMaxAge = 86400 # 1 day
 
 [metrics]
-  host = "127.0.0.1"
+  host = "0.0.0.0"
   port = 9000
   [metrics.gql]
     port = 9001


### PR DESCRIPTION
Part of [Setup grafana SO stack for monitoring watchers](https://www.notion.so/Setup-grafana-SO-stack-for-monitoring-watchers-7e23042c296c4de6b8676f1f604aa03c)