### PR TITLE
Use custom act with gitea.

### DIFF
--- a/.gitea/workflows/test-webapp.yml
+++ b/.gitea/workflows/test-webapp.yml
@@ -41,8 +41,7 @@ jobs:
         run: ./scripts/create_build_tag_file.sh
       - name: "Build local shiv package"
         run: ./scripts/build_shiv_package.sh
-      # 20240109 - Only needed until the executors are updated.
-      - name: "Install wget"
+      - name: "Install wget" # 20240109 - Only needed until the executors are updated.
         run: apt update && apt install -y wget
       - name: Start dockerd # Also needed until we can incorporate into the executor
         run: |

--- a/.gitea/workflows/test-webapp.yml
+++ b/.gitea/workflows/test-webapp.yml
@@ -41,6 +41,8 @@ jobs:
         run: ./scripts/create_build_tag_file.sh
       - name: "Build local shiv package"
         run: ./scripts/build_shiv_package.sh
+      - name: "Install wget"
+        run: apt update && apt install -y wget
       - name: Start dockerd # Also needed until we can incorporate into the executor
         run: |
           dockerd -H $DOCKER_HOST --userland-proxy=false &

--- a/.gitea/workflows/test-webapp.yml
+++ b/.gitea/workflows/test-webapp.yml
@@ -41,6 +41,7 @@ jobs:
         run: ./scripts/create_build_tag_file.sh
       - name: "Build local shiv package"
         run: ./scripts/build_shiv_package.sh
+      # 20240109 - Only needed until the executors are updated.
       - name: "Install wget"
         run: apt update && apt install -y wget
       - name: Start dockerd # Also needed until we can incorporate into the executor

--- a/stack_orchestrator/data/container-build/cerc-act-runner-task-executor/build.sh
+++ b/stack_orchestrator/data/container-build/cerc-act-runner-task-executor/build.sh
@@ -2,4 +2,6 @@
 # Build a local version of the task executor for act-runner
 source ${CERC_CONTAINER_BASE_DIR}/build-base.sh
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-docker build -t cerc/act-runner-task-executor:local -f ${CERC_REPO_BASE_DIR}/hosting/act-runner/Dockerfile.task-executor ${build_command_args} ${SCRIPT_DIR}
+
+cd ${CERC_REPO_BASE_DIR}/hosting/act-runner
+docker build -t cerc/act-runner-task-executor:local -f Dockerfile.task-executor ${build_command_args} .

--- a/stack_orchestrator/data/stacks/package-registry/stack.yml
+++ b/stack_orchestrator/data/stacks/package-registry/stack.yml
@@ -4,7 +4,7 @@ description: "Local Package Registry"
 repos:
   - github.com/telackey/gitea@telackey/entrypoint
   - git.vdb.to/cerc-io/hosting@dboreham/fix-dind
-  - gitea.com/gitea/act_runner@telackey/entrypoint
+  - gitea.com/telackey/act_runner@telackey/entrypoint
 containers:
   - cerc/gitea
   - cerc/act-runner

--- a/stack_orchestrator/data/stacks/package-registry/stack.yml
+++ b/stack_orchestrator/data/stacks/package-registry/stack.yml
@@ -2,9 +2,11 @@ version: "1.1"
 name: package-registry
 description: "Local Package Registry"
 repos:
-  - git.vdb.to/cerc-io/hosting
-  - gitea.com/gitea/act_runner
+  - github.com/telackey/gitea@telackey/entrypoint
+  - git.vdb.to/cerc-io/hosting@dboreham/fix-dind
+  - gitea.com/gitea/act_runner@telackey/entrypoint
 containers:
+  - cerc/gitea
   - cerc/act-runner
   - cerc/act-runner-task-executor
 pods:

--- a/stack_orchestrator/deploy/deployment_create.py
+++ b/stack_orchestrator/deploy/deployment_create.py
@@ -444,7 +444,7 @@ def create_operation(deployment_command_context, spec_file, deployment_dir, netw
     deployer_config_generator = getDeployerConfigGenerator(deployment_type)
     # TODO: make deployment_dir_path a Path above
     deployer_config_generator.generate(deployment_dir_path)
-    call_stack_deploy_create(deployment_context, [network_dir, initial_peers])
+    call_stack_deploy_create(deployment_context, [network_dir, initial_peers, deployment_command_context])
 
 
 # TODO: this code should be in the stack .py files but


### PR DESCRIPTION
Update the package-registry stack to use our forked gitea, act_runner, and act which does not override the task executor container's entrypoint.