### PR TITLE
Create next.config.js if it is missing.

### DIFF
--- a/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/build-app.sh
+++ b/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/build-app.sh
@@ -21,6 +21,10 @@ WORK_DIR="${1:-/app}"
 
 cd "${WORK_DIR}" || exit 1
 
+if [ ! -f "next.config.js" ]; then
+  touch next.config.js
+fi
+
 if [ ! -f "next.config.dist" ]; then
   cp next.config.js next.config.dist
 fi

--- a/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/build-app.sh
+++ b/stack_orchestrator/data/container-build/cerc-nextjs-base/scripts/build-app.sh
@@ -21,6 +21,7 @@ WORK_DIR="${1:-/app}"
 
 cd "${WORK_DIR}" || exit 1
 
+# If this file doesn't exist at all, we'll get errors below.
 if [ ! -f "next.config.js" ]; then
   touch next.config.js
 fi


### PR DESCRIPTION
In passing, I noticed a non-fatal error like this:

```
cp: cannot stat 'next.config.js': No such file or directory
```

When the project didn't have a `next.config.js` file.  I don't know if the project in question would work anyway, but for our purposes starting with a blank cfg is probably OK.