### PR TITLE
Update independent act-runner stack to use custom act as well.

### DIFF
--- a/stack_orchestrator/data/stacks/act-runner/stack.yml
+++ b/stack_orchestrator/data/stacks/act-runner/stack.yml
@@ -3,7 +3,7 @@ name: act-runner
 description: "Local act-runner"
 repos:
   - git.vdb.to/cerc-io/hosting
-  - gitea.com/gitea/act_runner
+  - gitea.com/telackey/act_runner@telackey/entrypoint
 containers:
   - cerc/act-runner
   - cerc/act-runner-task-executor

--- a/stack_orchestrator/data/stacks/package-registry/stack.yml
+++ b/stack_orchestrator/data/stacks/package-registry/stack.yml
@@ -2,11 +2,9 @@ version: "1.1"
 name: package-registry
 description: "Local Package Registry"
 repos:
-  - github.com/telackey/gitea@telackey/entrypoint
-  - git.vdb.to/cerc-io/hosting@dboreham/fix-dind
+  - git.vdb.to/cerc-io/hosting
   - gitea.com/telackey/act_runner@telackey/entrypoint
 containers:
-  - cerc/gitea
   - cerc/act-runner
   - cerc/act-runner-task-executor
 pods:


### PR DESCRIPTION
Related to https://github.com/cerc-io/stack-orchestrator/pull/700, update the independent act-runner stack as well.

Now that https://git.vdb.to/cerc-io/hosting/pulls/74 is merged, it also removes the reference to that branch for the regular gitea stack.