### PR TITLE
Fix pip3 error

### DIFF
--- a/stack_orchestrator/data/container-build/cerc-fixturenet-eth-genesis/Dockerfile
+++ b/stack_orchestrator/data/container-build/cerc-fixturenet-eth-genesis/Dockerfile
@@ -10,9 +10,10 @@ COPY genesis /opt/genesis
 COPY --from=ethgen /usr/local/bin/eth2-testnet-genesis /usr/local/bin/
 COPY --from=ethgen /usr/local/bin/eth2-val-tools /usr/local/bin/
 COPY --from=ethgen /apps /apps
-RUN cd /apps/el-gen && pip3 install -r requirements.txt
+RUN cd /apps/el-gen && pip3 install --break-system-packages -r requirements.txt
 # web3==5.24.0 used by el-gen is broken on python 3.11
-RUN pip3 install --upgrade "web3==6.5.0"
+RUN pip3 install --break-system-packages --upgrade "web3==6.5.0"
+RUN pip3 install --break-system-packages --upgrade "typing-extensions"
 
 # Build genesis config
 RUN apk add --no-cache make bash envsubst jq


### PR DESCRIPTION
Fix new error:

```
#15 [builder  7/12] RUN cd /apps/el-gen && pip3 install -r requirements.txt
#15 2.124 error: externally-managed-environment
#15 2.124 
#15 2.124 × This environment is externally managed
#15 2.124 ╰─> 
#15 2.124     The system-wide python installation should be maintained using the system
#15 2.124     package manager (apk) only.
#15 2.124     
#15 2.124     If the package in question is not packaged already (and hence installable via
#15 2.124     "apk add py3-somepackage"), please consider installing it inside a virtual
#15 2.124     environment, e.g.:
```