### PR TITLE
bug-fix: fix image-overrides usage to load locally build images into kind cluster

### DIFF
--- a/stack_orchestrator/deploy/k8s/deploy_k8s.py
+++ b/stack_orchestrator/deploy/k8s/deploy_k8s.py
@@ -30,6 +30,7 @@ from stack_orchestrator.deploy.k8s.helpers import (
     create_cluster,
     destroy_cluster,
     get_kind_cluster,
+    is_image_available_locally,
     load_images_into_kind,
 )
 from stack_orchestrator.deploy.k8s.helpers import (
@@ -833,9 +834,15 @@ class K8sDeployer(Deployer):
             actual_cluster = create_cluster(self.kind_cluster_name, kind_config)
             if actual_cluster != self.kind_cluster_name:
                 self.kind_cluster_name = actual_cluster
-            # Pre-load images into kind so pods can use them with
-            # imagePullPolicy: IfNotPresent before the registry is consulted.
-            images_to_preload = set((self.image_overrides or {}).values())
+            local_containers = self.deployment_context.stack.obj.get("containers", [])
+            images_to_preload = set((self.image_overrides or {}).values()) | {
+                img
+                for img in self.cluster_info.image_set
+                if any(c in img for c in local_containers)
+            }
+            images_to_preload = {
+                img for img in images_to_preload if is_image_available_locally(img)
+            }
             if images_to_preload:
                 load_images_into_kind(self.kind_cluster_name, images_to_preload)
         elif self.is_kind():

--- a/stack_orchestrator/deploy/k8s/deploy_k8s.py
+++ b/stack_orchestrator/deploy/k8s/deploy_k8s.py
@@ -833,16 +833,11 @@ class K8sDeployer(Deployer):
             actual_cluster = create_cluster(self.kind_cluster_name, kind_config)
             if actual_cluster != self.kind_cluster_name:
                 self.kind_cluster_name = actual_cluster
-            # Only load locally-built images into kind
-            local_containers = self.deployment_context.stack.obj.get("containers", [])
-            if local_containers:
-                local_images = {
-                    img
-                    for img in self.cluster_info.image_set
-                    if any(c in img for c in local_containers)
-                }
-                if local_images:
-                    load_images_into_kind(self.kind_cluster_name, local_images)
+            # Pre-load images into kind so pods can use them with
+            # imagePullPolicy: IfNotPresent before the registry is consulted.
+            images_to_preload = set((self.image_overrides or {}).values())
+            if images_to_preload:
+                load_images_into_kind(self.kind_cluster_name, images_to_preload)
         elif self.is_kind():
             # --skip-cluster-management (default): cluster must already exist.
             # Without this check, connect_api() below raises a cryptic

--- a/stack_orchestrator/deploy/k8s/helpers.py
+++ b/stack_orchestrator/deploy/k8s/helpers.py
@@ -607,6 +607,14 @@ def update_caddy_ingress_image(caddy_image: str) -> bool:
     return True
 
 
+def is_image_available_locally(image: str) -> bool:
+    result = subprocess.run(
+        ["docker", "image", "inspect", image],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
 def load_images_into_kind(kind_cluster_name: str, image_set: Set[str]):
     for image in image_set:
         result = _run_command(


### PR DESCRIPTION
- Cluster setup was only considering images from containers list in `stack.yml` for kind-loading into the cluster; i.e. images from `image_overrides` in spec were not being loaded
- This also resulted in laconic-so to attempt kind-loading images not present locally sometimes
- Fix: union `image_overrides` values (user-specified local images) with the ones from container-list, filtered to only ones that are actually present on the docker host