### PR TITLE
Support a label to allow re-running completed k8s Jobs on deploy

### DIFF
--- a/stack_orchestrator/deploy/k8s/cluster_info.py
+++ b/stack_orchestrator/deploy/k8s/cluster_info.py
@@ -1160,12 +1160,26 @@ class ClusterInfo:
                 backoff_limit=0,
             )
             job_labels = self._stack_labels()
+            recreate = False
+            for svc in (_services or {}).values():
+                svc_labels = svc.get("labels", {})
+                if isinstance(svc_labels, list):
+                    svc_labels = dict(item.split("=", 1) for item in svc_labels)
+                if str(svc_labels.get("laconic.recreate-job", "")).lower() in (
+                    "true",
+                    "1",
+                    "yes",
+                ):
+                    recreate = True
+                    break
+            job_annotations = {"laconic.recreate-job": "true"} if recreate else None
             job = client.V1Job(
                 api_version="batch/v1",
                 kind="Job",
                 metadata=client.V1ObjectMeta(
                     name=f"{self.app_name}-job-{job_name}",
                     labels=job_labels,
+                    annotations=job_annotations,
                 ),
                 spec=job_spec,
             )

--- a/stack_orchestrator/deploy/k8s/deploy_k8s.py
+++ b/stack_orchestrator/deploy/k8s/deploy_k8s.py
@@ -732,7 +732,9 @@ class K8sDeployer(Deployer):
                         namespace=self.k8s_namespace,
                         body=body,
                     )
-                    print(f"Updated user Secret '{secret_name}' in {self.k8s_namespace}")
+                    print(
+                        f"Updated user Secret '{secret_name}' in {self.k8s_namespace}"
+                    )
                 else:
                     raise
 
@@ -844,6 +846,37 @@ class K8sDeployer(Deployer):
                 if opts.o.debug:
                     print(f"  {service_resp}")
 
+    def _delete_job_and_wait(self, job_name, timeout=120):
+        """Delete a Job (cascading to its pods) and block until it's gone.
+
+        Jobs are one-shot/immutable; to re-run one we must delete then recreate.
+        """
+        import time
+
+        try:
+            self.batch_api.delete_namespaced_job(
+                name=job_name,
+                namespace=self.k8s_namespace,
+                body=client.V1DeleteOptions(propagation_policy="Background"),
+            )
+            print(f"Deleting Job {job_name} for recreate")
+        except ApiException as e:
+            if e.status == 404:
+                return
+            raise
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                self.batch_api.read_namespaced_job(
+                    name=job_name, namespace=self.k8s_namespace
+                )
+            except ApiException as e:
+                if e.status == 404:
+                    return
+                raise
+            time.sleep(2)
+        raise TimeoutError(f"Job {job_name} not deleted within {timeout}s")
+
     def _create_jobs(self):
         # Process job compose files into k8s Jobs
         job_pull_policy = "IfNotPresent" if self.is_kind() else "Always"
@@ -853,6 +886,14 @@ class K8sDeployer(Deployer):
                 print(f"Sending this job: {job}")
             if not opts.o.dry_run:
                 job_name = job.metadata.name
+                anns = job.metadata.annotations or {}
+                recreate = str(anns.get("laconic.recreate-job", "")).lower() in (
+                    "true",
+                    "1",
+                    "yes",
+                )
+                if recreate:
+                    self._delete_job_and_wait(job_name)
                 try:
                     job_resp = self.batch_api.create_namespaced_job(
                         body=job, namespace=self.k8s_namespace

--- a/tests/unit/test_recreate_job.py
+++ b/tests/unit/test_recreate_job.py
@@ -1,0 +1,80 @@
+"""Unit tests for K8sDeployer._create_jobs() recreate behavior."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from kubernetes.client.exceptions import ApiException
+
+from stack_orchestrator.command_types import CommandOptions
+
+
+class TestCreateJobsRecreate(unittest.TestCase):
+    def setUp(self):
+        from stack_orchestrator.deploy.k8s.deploy_k8s import K8sDeployer
+
+        self.deployer = K8sDeployer.__new__(K8sDeployer)
+        self.deployer.type = "k8s"
+        self.deployer.k8s_namespace = "test-ns"
+        self.deployer.batch_api = MagicMock()
+        self.deployer.cluster_info = MagicMock()
+        self._opts_patch = patch(
+            "stack_orchestrator.deploy.k8s.deploy_k8s.opts.o",
+            CommandOptions(stack=""),
+        )
+        self._opts_patch.start()
+
+    def tearDown(self):
+        self._opts_patch.stop()
+
+    def test_recreate_deletes_then_creates(self):
+        job = MagicMock()
+        job.metadata.name = "warp-deployer-job"
+        job.metadata.annotations = {"laconic.recreate-job": "true"}
+        self.deployer.cluster_info.get_jobs = lambda image_pull_policy=None: [job]
+        # read returns 404 immediately after delete -> _delete_job_and_wait returns
+        self.deployer.batch_api.read_namespaced_job.side_effect = ApiException(
+            status=404
+        )
+        self.deployer._create_jobs()
+        self.deployer.batch_api.delete_namespaced_job.assert_called_once()
+        self.deployer.batch_api.create_namespaced_job.assert_called_once()
+
+    def test_no_annotation_skips_delete(self):
+        job = MagicMock()
+        job.metadata.name = "warp-deployer-job"
+        job.metadata.annotations = None
+        self.deployer.cluster_info.get_jobs = lambda image_pull_policy=None: [job]
+        self.deployer._create_jobs()
+        self.deployer.batch_api.delete_namespaced_job.assert_not_called()
+        self.deployer.batch_api.create_namespaced_job.assert_called_once()
+
+
+class TestGetJobsRecreateAnnotation(unittest.TestCase):
+    """Exercise the label->annotation logic in ClusterInfo.get_jobs()."""
+
+    def _build_jobs(self, services):
+        from stack_orchestrator.deploy.k8s.cluster_info import ClusterInfo
+
+        ci = ClusterInfo.__new__(ClusterInfo)
+        ci.app_name = "myapp"
+        ci.spec = MagicMock()
+        ci.spec.get_image_registry_config.return_value = None
+        ci.parsed_job_yaml_map = {"docker-compose-foo.yml": {}}
+        ci._stack_labels = lambda extra=None: {"app": ci.app_name}
+        ci._build_containers = MagicMock(return_value=([], [], services, []))
+        return ci.get_jobs()
+
+    def test_dict_label_true_sets_annotation(self):
+        jobs = self._build_jobs({"svc": {"labels": {"laconic.recreate-job": "true"}}})
+        self.assertEqual(jobs[0].metadata.annotations, {"laconic.recreate-job": "true"})
+
+    def test_list_label_true_sets_annotation(self):
+        jobs = self._build_jobs({"svc": {"labels": ["laconic.recreate-job=true"]}})
+        self.assertEqual(jobs[0].metadata.annotations, {"laconic.recreate-job": "true"})
+
+    def test_no_label_leaves_annotation_none(self):
+        jobs = self._build_jobs({"svc": {"labels": {}}})
+        self.assertIsNone(jobs[0].metadata.annotations)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Adds support for a `laconic.recreate-job` compose label. Any service carrying it gets the same annotation stamped onto its generated k8s Job
- On deploy, a Job marked for recreate is deleted (cascading to its pods) and recreated instead of erroring because the Job already exists
- The delete blocks until the old Job is fully gone (bounded by a timeout) before recreating, so each run starts clean
- Adds unit tests for the label -> annotation propagation and the delete-then-recreate path
